### PR TITLE
Dev base path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,10 +3,9 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import configureStore from './store/configureStore.js';
-import defaultState from './store/defaultState.js';
 import {routes} from './routes.js';
 
-const store = configureStore(defaultState);
+const store = configureStore();
 
 // NOTE: this requires the javascript to be loaded at the bottom of the page
 // or at least after the id="root" element

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,7 +11,7 @@ export const appLocation = (Config.USE_HASH_BROWSING ? hashHistory : browserHist
 export const routes = (
      <Router history={appLocation}>
       <Route path={baseAppPath} >
-        <Route path="sign/:petition_slug" component={SignPetition}/>
-        <Route path="thanks.html" component={Thanks}/>
+        <Route path="/sign/:petition_slug" component={SignPetition}/>
+        <Route path="/thanks.html" component={Thanks}/>
       </Route>
     </Router>);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ var config = {
   devtool: 'sourcemap',
   output: {
     path: BUILD_DIR,
-    publicPath: process.env.STATIC_ROOT || "/build/",
+    publicPath: process.env.PUBLIC_ROOT || "/",
     //NOTE: when process.env.PROD is true this will be the minified file
     //TODO: maybe we should hash this and figure out a way to pass the hashed version to it
     filename: 'main.js'


### PR DESCRIPTION
This allows dev loading at e.g. `/#/sign/outkast` instead of `/build/#/sign/outkast`