### PR TITLE
add dispatch to petition preload and remove signature preload

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -19,9 +19,12 @@ export const actionTypes = {
 export function loadPetition(petitionSlug) {
   const urlKey = `petitions/${petitionSlug}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
-    return {
-      type: actionTypes.FETCH_PETITION_SUCCESS,
-      petition: window.preloadObjects[urlKey]
+    return (dispatch) => {
+      dispatch({
+        type: actionTypes.FETCH_PETITION_SUCCESS,
+        petition: window.preloadObjects[urlKey],
+        slug: petitionSlug
+      })
     }
   }
   return (dispatch) => {
@@ -67,13 +70,6 @@ export function signPetition(petitionSignature, petition) {
 
 export const loadPetitionSignatures = (petitionSlug, page = 1) => {
   const urlKey = `petitions/${petitionSlug}/signatures`
-  // TODO: include page in URL when API supports.
-  if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
-    return {
-      type: actionTypes.FETCH_PETITION_SIGNATURES_SUCCESS,
-      petition: window.preloadObjects[urlKey]
-    }
-  }
   return (dispatch) => {
     dispatch({
       type: actionTypes.FETCH_PETITION_SIGNATURES_REQUEST,


### PR DESCRIPTION
Preloading didn't seem to be working with just returning the object, and does work with returning the dispatch of the object. Also, preloading signatures wasn't working and maybe isn't worth doing at all, so just removed to potentially add a working version later.