### PR TITLE
Thanks page and session awareness

### DIFF
--- a/local/api/v1/petitions/outkast.json
+++ b/local/api/v1/petitions/outkast.json
@@ -18,5 +18,10 @@
           "ocd-division": "ocd-division/country:us/state:ga/sldu"
         }
     ],
-    "title": "Georgia: Add Outkast to Stone Mountain!"
+    "title": "Georgia: Add Outkast to Stone Mountain!",
+    "share_options": [{
+      "twitter_share": {
+        "message": "Tell Georgia to add Outkast to Stone Mountain! [URL]"
+      }
+    }]
 }

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -194,6 +194,19 @@ class SignatureAddForm extends React.Component {
 
   render() {
     const statement = text2paraJsx(this.props.petition.summary)
+    const user = this.props.user
+    if (user && user.signonId) {
+      return (  <div>            <div className='form-group'>
+                <label htmlFor='comment'>Comment</label>
+                <textarea className='moveon-track-click' rows='3' cols='20' name='comment' id='comment' autoComplete='off' onChange={this.updateStateFromValue('comment')} onBlur={this.updateStateFromValue('comment')}></textarea>
+              </div>
+              <div className='form-group form-group--submit'>
+                <button type='submit' className='xl percent-100 moveon-track-click background-moveon-bright-red' id='sign-here-button' value='Sign the petition!'>Sign the petition</button>
+              </div>
+              <p className='disclaimer bump-top-1'><b>Note:</b> By signing, you agree to receive email messages from MoveOn.org Civic Action and MoveOn.org Political Action. You may unsubscribe at any time. [ <a href='http://petitions.moveon.org/privacy.html'>Privacy policy</a> ]</p>
+                            </div>
+)
+    } else
     return (
       <div className='span4 widget clearfix' id='sign-here'>
         <div className='petition-top visible-phone'>
@@ -502,7 +515,14 @@ class SignatureAddForm extends React.Component {
 
 SignatureAddForm.propTypes = {
   petition: PropTypes.object.isRequired,
+  user: PropTypes.object,
   dispatch: PropTypes.func
 }
 
-export default connect()(SignatureAddForm)
+function mapStateToProps(store, ownProps) {
+  return {
+    user: store.userStore
+  }
+}
+
+export default connect(mapStateToProps)(SignatureAddForm)

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -1,14 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Thanks = ({ petition }) => (
+const Thanks = ({ petition, user }) => (
   <div className='container background-moveon-white' role='main'>
-    Thanks Yo! <a href={petition._links.url} >{petition.petition_id}</a>
+    <div>
+    Thank You
+    {((user.full_name || user.given_name) ?
+      <span>, {user.full_name || user.given_name}</span>
+      : '')}!
+    </div>
+    <a href={petition._links.url} >{petition.petition_id}</a>
   </div>
 )
 
 Thanks.propTypes = {
-  petition: PropTypes.object
+  petition: PropTypes.object,
+  user: PropTypes.object
 }
 
 export default Thanks

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -1,17 +1,103 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { moNumber2base62 } from '../lib'
 
-const Thanks = ({ petition, user }) => (
-  <div className='container background-moveon-white' role='main'>
-    <div>
-    Thank You
-    {((user.full_name || user.given_name) ?
-      <span>, {user.full_name || user.given_name}</span>
-      : '')}!
-    </div>
-    <a href={petition._links.url} >{petition.petition_id}</a>
-  </div>
-)
+class Thanks extends React.Component {
+
+  shareLink(evt) {
+    evt.target.select()
+  }
+
+  shareEmail(evt) {
+    // note: currently non-bound method, so `this` will not work
+    evt.target.select()
+    // this.focus();this.select(); record_share_click('email', 's.em.cp')
+  }
+
+  render() {
+    /*
+      share_url handling:
+     */
+    const { petition, user } = this.props
+    const creator = false // maybe test user.id==petition.creator_id or something, if we want to expose that
+    const pre = (creator ? 'c' : 's') // TODO: based on ?from_source= parameter .icn and .imn, megapartner
+    const actedOn = (creator ? 'created' : 'signed')
+    const userId = user.signonId || '123' // TODO
+    const link = petition._links.url // TODO: ref_by_id, shortening, etc
+    const target = (petition.target.slice(0,3).map(t => t.name).join(' and ')
+                    + ((petition.target.length > 3) ? ' and others' : ''))
+    const shareOpts = (petition.share_options && petition.share_options[0]) || {}
+    // convert description to text
+    const textDescription = document.createElement('div')
+    textDescription.innerHTML = petition.description
+    let tweet
+    if (shareOpts.twitter_share && shareOpts.twitter_share.message) {
+      tweet = shareOpts.twitter_share.message.replace('[URL]', link)
+    } else {
+      const suffix = ` ${link} @moveon`
+      tweet = `${petition.title.slice(0, 140 - suffix.length)} ${suffix}`
+    }
+
+    // TODO: previous code for mailToMessage tries a bunch of permutations if this is >1024 characters. 
+    // We could possibly implement this by making any of these versions server-side
+    const mailToMessage = (shareOpts.email_share || `Hi,
+
+${textDescription.textContent}
+
+That\'s why I ${actedOn} a petition to ${target}, which says:
+
+"${petition.summary}"
+
+Will you sign this petition? Click here:
+
+${link}?source=${pre}.em.__TYPE__&r_by=${userId}
+
+Thanks!
+`)    const copyPasteMessage = `Subject: ${petition.summary}\n\n${mailToMessage}`
+
+    return (<div className='row'>
+      <div className='span4'>
+        <h1 className='size-superxl lh-100 font-lighter'>Thanks!</h1>
+      </div>
+      <div className='span5 offset1 bump-top-3 font-lighter lh-24'>
+        Now that you have {((creator) ? 'created' : 'signed')},
+        <span className='font-heavy moveon-bright-red'> help it grow</span> by asking your friends, family, colleagues to sign.
+      </div>
+      <div className='clear hidden-phone border-bottom'></div>
+      <div className='share-area'>
+        <div className='span4 share-social-media padding-top-1 align-center pull-right'>
+          <div className='lanky-header'>
+            <span className='icon-fb-default'></span>
+            Tell your friends on Facebook:
+          </div>
+          <button id='facebook-button' className='xl300 background-facebook-blue'>Share on Facebook</button>
+          <div className='lanky-header bump-top-3 align-center'>
+            <span className='icon-twitter-default'></span>
+            Tweet your followers:
+          </div>
+          <button id='twitter-button' className='xl300 background-moveon-bright-red'>Tweet This</button>
+          <textarea className='hidden' id='tweet_text' defaultValue={tweet}></textarea>
+          <div className='lanky-header bump-top-3 align-center'>
+            Send a link:
+          </div>
+          <textarea
+            ref={(input) => { this.linkTextarea = input }}
+            onClick={this.shareLink}
+            id='link_text' defaultValue={link}
+          ></textarea>
+        </div>
+        <div className='span7 padding-top-1'>
+          <div className='share-email align-center'>
+            <div className='lanky-header align-center'><span className='icon-join-default'></span>Email your friends, family and colleagues:</div>
+            <a id='email-button' href='mailto:?subject={encodeURIComponent(petition.summary)}&body={encodeURIComponent(mailToMessage.replace("__TYPE__","mt")}' className='button xl300 background-moveon-bright-red'>Email your friends</a>
+            <div className='disclaimer bump-top-3 hidden-phone'>Or copy and paste the text below into a message:</div>
+            <textarea ref={(input) => { this.emailTextarea = input }} className='hidden-phone' id='email-textarea' onClick={this.shareEmail} value={copyPasteMessage.replace("__TYPE__","cp")}></textarea>
+          </div>
+        </div>
+      </div>
+    </div>)
+  }
+}
 
 Thanks.propTypes = {
   petition: PropTypes.object,

--- a/src/lib.js
+++ b/src/lib.js
@@ -23,8 +23,23 @@ const text2paraJsx = (str) => {
   })
 }
 
+const moNumber2base62 = (num) => {
+  // This converts a number to base62, and will be used to generate petition redirect urls
+  // example: 125962 => 'pju'
+  const base62 = 'BCDFoHJKLMNPQRSTVWXYZAEIOU012345p789aeiGubcdfghjklzn6qrstvwxym'
+  const char62s = []
+  let numLeft = num
+  let tooMany = 13
+  while (numLeft > 0 && --tooMany) {
+    char62s.push(base62[numLeft % 62])
+    numLeft = parseInt(numLeft / 62, 10)
+  }
+  return char62s.reverse().join('')
+}
+
 export {
   formatDate,
   text2paras,
-  text2paraJsx
+  text2paraJsx,
+  moNumber2base62
 }

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -26,7 +26,6 @@ class ThanksPage extends React.Component {
   render() {
     return (
       <div>
-        <div>test loaded</div>
         {(this.Thanks && this.props.petition ?
           <this.Thanks petition={this.props.petition} user={this.props.user} /> :
           ''

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -28,7 +28,7 @@ class ThanksPage extends React.Component {
       <div>
         <div>test loaded</div>
         {(this.Thanks && this.props.petition ?
-          <this.Thanks petition={this.props.petition} /> :
+          <this.Thanks petition={this.props.petition} user={this.props.user} /> :
           ''
         )}
       </div>
@@ -39,6 +39,7 @@ class ThanksPage extends React.Component {
 
 ThanksPage.propTypes = {
   petition: PropTypes.object,
+  user: PropTypes.object,
   location: PropTypes.object,
   dispatch: PropTypes.func
 }
@@ -46,7 +47,8 @@ ThanksPage.propTypes = {
 function mapStateToProps(store, ownProps) {
   const pkey = ownProps.location.query.name || ownProps.location.query.petition_id
   return {
-    petition: pkey && store.petitionStore.petitions[pkey]
+    petition: pkey && store.petitionStore.petitions[pkey],
+    user: store.userStore
   }
 }
 


### PR DESCRIPTION
Implements old html for the thanks page
I think this should be mergeable, but more to do on thanks page:

 - [ ] sharebandit integration
 - [ ] facebook and google analytics tracking (loading, and on sharing actions, etc.)
 - [ ] create petition short codes
 - [ ] signonId fallback (to generate petition shortcode)