### PR TITLE
add first two good tests to petition signature-add-form

### DIFF
--- a/local/index.html
+++ b/local/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <title>MoveOn Petitions</title>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    <meta http-equiv="Content-Style-Type" content="text/css" />
+    <meta name="viewport" content="width=device-width, initial-scale=0.9" />
     <link rel='stylesheet' href="<%= htmlWebpackPlugin.options.cssPath %>" type='text/css' media='all' />
   </head>
   <body class="moveon-petitions">

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/MoveOnOrg/mop-frontend",
   "directories": {},
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --require isomorphic-fetch test test/*",
+    "test": "mocha --compilers js:babel-core/register --require jsdom-global/register --require isomorphic-fetch test test/*",
+    "test1": "mocha --compilers js:babel-core/register --require jsdom-global/register --require isomorphic-fetch test ",
     "build": "webpack -d",
     "webpack-watch": "webpack -w",
     "dev": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --progress --colors --port ${PORT:-8080} --inline",
@@ -43,6 +44,8 @@
     "file-loader": "^0.11.1",
     "html-webpack-plugin": "^2.22.0",
     "isomorphic-fetch": "^2.2.1",
+    "jsdom": "11.5.1",
+    "jsdom-global": "3.0.2",
     "mocha": "~3.2.0",
     "nock": "^9.0.13",
     "react-addons-test-utils": "^15.4.2",

--- a/src/components/petition.js
+++ b/src/components/petition.js
@@ -65,7 +65,7 @@ class Petition extends React.Component {
               <div className='petition-top hidden-phone'>
                 <h1 id='petition-title' className='moveon-bright-red big-title'>{p.title}</h1>
                 <p id='by' className='byline lh-20'>
-                  Petition by <a href='/contact_creator.html?petition_id=95935' className='underline'>
+                  Petition by <a href={`/contact_creator.html?petition_id=${p.petition_id}`} className='underline'>
                       {petitionBy}
                   </a>
                 </p>

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -139,7 +139,7 @@ class SignatureAddForm extends React.Component {
 
   updateRequiredFields(doUpdate) {
     // This is a separate method because it can change when state or props are changed
-    const { user, petition, requireAddressFields } = this.props
+    const { user, requireAddressFields } = this.props
     const required = this.state.required
     let changeRequiredFields = false
     if (!user.signonId) {

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -8,6 +8,8 @@ import ZipOrPostalInput from './form/zip-or-postal-input'
 import { actions as petitionActions } from '../actions/petitionActions.js'
 import { actions as sessionActions } from '../actions/sessionActions.js'
 
+
+
 class SignatureAddForm extends React.Component {
 
   constructor(props) {
@@ -26,9 +28,14 @@ class SignatureAddForm extends React.Component {
       comment: false,
       volunteer: false,
       phone: false,
-      submitTried: false,
+      validationTried: false,
       thirdparty_optin: props.showOptinCheckbox,
-      required: {}
+      required: {},
+    }
+    this.validationRegex = {
+      email: /.+@.+\..+/, // forgiving email regex
+      zip: /(\d\D*){5}/,
+      phone: /(\d\D*){10}/, // 10-digits
     }
 
     this.volunteer = this.volunteer.bind(this)
@@ -37,9 +44,10 @@ class SignatureAddForm extends React.Component {
     this.updateStateFromValue = this.updateStateFromValue.bind(this)
   }
 
-  validationError(key, regex) {
-    if (this.state.submitTried) {
+  validationError(key) {
+    if (this.state.validationTried) {
       if (Object.keys(this.state.required).indexOf(key) > -1) {
+        const regex = this.validationRegex[key]
         if (!this.state[key] || (regex && !regex.test(String(this.state[key])))) {
           return (
             <div className='alert alert-danger' role='alert'>{this.state.required[key]}</div>
@@ -51,6 +59,8 @@ class SignatureAddForm extends React.Component {
   }
 
   formIsValid() {
+    this.setState({ validationTried: true })
+    this.updateRequiredFields(true)
     return Object.keys(this.state.required).map(key => !!this.state[key]).reduce((a, b) => a && b, true)
   }
 
@@ -62,7 +72,7 @@ class SignatureAddForm extends React.Component {
 
   volunteer(event) {
     const vol = event.target.checked
-    const req = this.updateRequired(false)
+    const req = this.updateRequiredFields(false)
     if (vol) {
       req.phone = 'We need a phone number to coordinate volunteers.'
     } else {
@@ -72,11 +82,11 @@ class SignatureAddForm extends React.Component {
       required: req })
   }
 
-  updateRequired(doUpdate) {
+  updateRequiredFields(doUpdate) {
     // This is a separate method because it can change when state or props are changed
     const { user, petition, showAddressFields } = this.props
     const required = this.state.required
-    let changeRequired = false
+    let changeRequiredFields = false
     if (!user.signonId) {
       Object.assign(required, {
         name: 'Name is required.',
@@ -84,7 +94,7 @@ class SignatureAddForm extends React.Component {
         state: 'State is required.',
         zip: 'Zip code is required.'
       })
-      changeRequired = true
+      changeRequiredFields = true
     } else {
       delete required.name
       delete required.email
@@ -98,7 +108,7 @@ class SignatureAddForm extends React.Component {
         state: 'State is required.',
         zip: 'Zip code is required.'
       })
-      changeRequired = true
+      changeRequiredFields = true
     } else {
       delete required.address1
       delete required.city
@@ -106,85 +116,96 @@ class SignatureAddForm extends React.Component {
     if (this.state.country !== 'United States') {
       delete required.state
     }
-    if (changeRequired && doUpdate) {
+    if (changeRequiredFields && doUpdate) {
       this.setState({ required })
     }
     return required
   }
 
+  getOsdiSignature() {
+    const { petition, user } = this.props
+    // TODO: thirdparty_optin, hidden_optin, volunteer
+    //       source, r_by, fb_test, abid, abver, test_group, no_mo, mailing_id
+    // - where to set thirdparty_optin to true at first? for checkbox
+    const osdiSignature = {
+      petition: {
+        name: petition.name,
+        petition_id: petition.petition_id,
+        _links: petition._links
+      },
+      person: {
+        full_name: this.state.name,
+        email_addresses: [],
+        postal_addresses: []
+      },
+      comments: this.state.comment
+    }
+    if (this.state.name) {
+      osdiSignature.person.full_name = this.state.name
+    } else if (user.given_name) {
+      osdiSignature.person.given_name = user.given_name
+    }
+    if (this.state.email) {
+      osdiSignature.person.email_addresses.push({
+        address: this.state.email
+      })
+    }
+    if (user.token) {
+      osdiSignature.person.identifiers = [user.token]
+    }
+    if (this.state.phone) {
+      osdiSignature.person.phone_numbers = [this.state.phone]
+    }
+    if (this.state.city) {
+      osdiSignature.person.postal_addresses.push({
+        locality: this.state.city,
+        region: ((this.state.country === 'United States') ? this.state.state : this.state.region),
+        postal_code: ((this.state.country === 'United States') ? this.state.zip : this.state.postal),
+        country_name: this.state.country
+      })
+    }
+    if (this.state.address1) {
+      const lines = [this.state.address1]
+      if (this.state.address2) {
+        lines.push(this.state.address2)
+      }
+      osdiSignature.person.postal_addresses[0].address_lines = lines
+    }
+    return osdiSignature
+  }
+
   submit(event) {
     event.preventDefault()
-
-    const { dispatch, petition, user } = this.props
-    this.updateRequired(true)
+    const { dispatch, petition } = this.props
     if (this.formIsValid()) {
-      // TODO: thirdparty_optin, hidden_optin, volunteer
-      //       source, r_by, fb_test, abid, abver, test_group, no_mo, mailing_id
-      // - where to set thirdparty_optin to true at first? for checkbox
-      const osdiSignature = {
-        petition: {
-          name: petition.name,
-          petition_id: petition.petition_id,
-          _links: petition._links
-        },
-        person: {
-          full_name: this.state.name,
-          email_addresses: [],
-          postal_addresses: []
-        },
-        comments: this.state.comment
-      }
-      if (this.state.name) {
-        osdiSignature.person.full_name = this.state.name
-      } else if (user.given_name) {
-        osdiSignature.person.given_name = user.given_name
-      }
-      if (this.state.email) {
-        osdiSignature.person.email_addresses.push({
-          address: this.state.email
-        })
-      }
-      if (user.token) {
-        osdiSignature.person.identifiers = [user.token]
-      }
-      if (this.state.phone) {
-        osdiSignature.person.phone_numbers = [this.state.phone]
-      }
-      if (this.state.city) {
-        osdiSignature.person.postal_addresses.push({
-          locality: this.state.city,
-          region: ((this.state.country === 'United States') ? this.state.state : this.state.region),
-          postal_code: ((this.state.country === 'United States') ? this.state.zip : this.state.postal),
-          country_name: this.state.country
-        })
-      }
-      if (this.state.address1) {
-        const lines = [this.state.address1]
-        if (this.state.address2) {
-          lines.push(this.state.address2)
-        }
-        osdiSignature.person.postal_addresses[0].address_lines = lines
-      }
+      const osdiSignature = this.getOsdiSignature()
       dispatch(petitionActions.signPetition(osdiSignature, petition, { redirectOnSuccess: true }))
     }
-    this.setState({ submitTried: true })
     return false
   }
 
   render() {
     const { dispatch, petition, user, query, showAddressFields } = this.props
     const creator = (petition._embedded && petition._embedded.creator || {})
+    const petitionBy = creator.name + (creator.organization
+                                       ? `, ${creator.organization}`
+                                       : '')
     const iframeEmbedText = `<iframe src="http://petitions.moveon.org/embed/widget.html?v=3&amp;name=${petition.slug}" class="moveon-petition" id="petition-embed" width="300px" height="500px"></iframe>` // text to be copy/pasted
     return (
       <div className='span4 widget clearfix' id='sign-here'>
         <div className='padding-left-15 form-wrapper background-moveon-light-gray padding-top-1 padding-bottom-1' style={{ paddingRight: 15, position: 'relative', top: -10 }}>
           <div className='petition-top visible-phone' style={{ paddingLeft: 20 }}>
-            <a style={{ float: 'right' }} href='/admin/petition_zoom.html?petition_id=125956'>zoom&nbsp;&#x270e;</a>
-            <p id='to-target' className='lh-14 bump-top-1 bump-bottom-1 margin-0 disclaimer'>Petition statement to be delivered to <span className='all-targets'><strong>Fox News and President Donald Trump</strong></span></p>
+            {(user.admin_petition_link) ?
+              <a style={{ float: 'right' }} href={`${user.admin_petition_link}?petition_id=${petition.petition_id}`}>zoom&nbsp;&#x270e;</a>
+             : ''}
+            <p id='to-target' className='lh-14 bump-top-1 bump-bottom-1 margin-0 disclaimer'>
+              Petition statement to be delivered to <span className='all-targets'>
+                <strong>{petition.target.map((t) => t.name).join(', ')}</strong>
+              </span>
+            </p>
             <h1 id='petition-title' className='moveon-bright-red big-title'>{petition.title}</h1>
             <p id='by' className='byline lh-20'>
-              Petition by
-              <a href='/contact_creator.html?petition_id=125956' className='underline'>Tom Steyer</a>
+              Petition by <a href={`/contact_creator.html?petition_id=${petition.petition_id}`} className='underline'>{petitionBy}</a>
             </p>
           </div>
 
@@ -236,7 +257,7 @@ class SignatureAddForm extends React.Component {
                   onChange={this.updateStateFromValue('email')}
                   onBlur={this.updateStateFromValue('email')}
                 />
-                 {this.validationError('email', /* forgiving email regex */ /.+@.+\..+/)}
+                 {this.validationError('email')}
               </div>
              )}
 
@@ -283,7 +304,7 @@ class SignatureAddForm extends React.Component {
                    zipOnChange={this.updateStateFromValue('zip')}
                    postalOnChange={this.updateStateFromValue('postal')}
                  />
-                 {this.validationError('zip', /(\d\D*){5}/)}
+                 {this.validationError('zip')}
                </div>
              ) : ''}
 
@@ -303,7 +324,7 @@ class SignatureAddForm extends React.Component {
                       onChange={this.updateStateFromValue('phone')}
                       onBlur={this.updateStateFromValue('phone')}
                     />
-                    {this.validationError('phone', /* 10 digits*/ /(\d\D*){10}/)}
+                    {this.validationError('phone')}
                   </div>
                 ) : ''}
               </div>)

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -28,7 +28,8 @@ class SignatureAddForm extends React.Component {
       volunteer: false,
       phone: false,
       validationTried: false,
-      thirdparty_optin: props.showOptinCheckbox,
+      thirdparty_optin: props.hiddenOptin || props.showOptinCheckbox,
+      hidden_optin: props.hiddenOptin,
       required: {}
     }
     this.validationRegex = {
@@ -44,10 +45,7 @@ class SignatureAddForm extends React.Component {
   }
 
   getOsdiSignature() {
-    const { petition, user } = this.props
-    // TODO: thirdparty_optin, hidden_optin, volunteer
-    //       source, r_by, fb_test, abid, abver, test_group, no_mo, mailing_id
-    // - where to set thirdparty_optin to true at first? for checkbox
+    const { petition, query, user } = this.props
     const osdiSignature = {
       petition: {
         name: petition.name,
@@ -92,6 +90,18 @@ class SignatureAddForm extends React.Component {
       }
       osdiSignature.person.postal_addresses[0].address_lines = lines
     }
+    const referrerKeys = [
+      'source', 'r_by', 'fb_test', 'abid', 'abver', 'test_group', 'no_mo', 'mailing_id', 'r_hash']
+    const referrerData = referrerKeys.filter(k => query[k]).map(k => ({ [k]: query[k] }))
+    if (referrerData.length) {
+      osdiSignature.referrer_data = Object.assign({}, ...referrerData)
+    }
+    const customFields = ['thirdparty_optin', 'hidden_optin', 'volunteer']
+    const customData = customFields.filter(k => this.state[k]).map(k => ({ [k]: this.state[k] }))
+    if (customData.length) {
+      osdiSignature.person.custom_fields = Object.assign({}, ...customData)
+    }
+    // console.log('signature!', osdiSignature)
     return osdiSignature
   }
 

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -41,7 +41,20 @@ describe('<SignatureAddForm />', () => {
       expect(dom.find('#sign-here').text().match(/Sign this petition/)[0]).to.equal('Sign this petition');
     });
 
-    //it('TODO:anonymous fields displaying', () => {});
+    it('anonymous fields displaying', () => {
+      const context = shallowWithStore(<SignatureAddForm {...propsProfileBase} />,
+                                       createMockStore(storeAnonymous))
+      expect(context.props().user.anonymous).to.be.equal(true)
+      const dom = context.render()
+      expect(dom.find('input[name="name"]').length).to.equal(1);
+      expect(dom.find('input[name="email"]').length).to.equal(1);
+      expect(dom.find('input[name="address1"]').length).to.equal(1);
+      expect(dom.find('input[name="address2"]').length).to.equal(1);
+      expect(dom.find('input[name="city"]').length).to.equal(1);
+      // not testing state because state is a sub component
+      // expect(dom.find('input[name="state"]').length).to.equal(1);
+      expect(dom.find('input[name="zip"]').length).to.equal(1);
+    });
 
     //it('TODO:user fields displaying', () => {});
 

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -34,31 +34,58 @@ describe('<SignatureAddForm />', () => {
 
   describe('<SignatureAddForm /> static tests', () => {
     it('basic loading', () => {
-      const context = shallowWithStore(<SignatureAddForm {...propsProfileBase} />,
-                                       createMockStore(storeAnonymous))
-      expect(context.props().user.anonymous).to.be.equal(true)
-      const dom = context.render()
-      expect(dom.find('#sign-here').text().match(/Sign this petition/)[0]).to.equal('Sign this petition');
+      const store = createMockStore(storeAnonymous)
+      const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
+      const component = unwrapReduxComponent(context)
+      expect(component.props.user.anonymous).to.be.equal(true)
+      expect(context.find('#sign-here').text().match(/Sign this petition/)[0]).to.equal('Sign this petition');
     });
 
     it('anonymous fields displaying', () => {
-      const context = shallowWithStore(<SignatureAddForm {...propsProfileBase} />,
-                                       createMockStore(storeAnonymous))
-      expect(context.props().user.anonymous).to.be.equal(true)
-      const dom = context.render()
-      expect(dom.find('input[name="name"]').length).to.equal(1);
-      expect(dom.find('input[name="email"]').length).to.equal(1);
-      expect(dom.find('input[name="address1"]').length).to.equal(1);
-      expect(dom.find('input[name="address2"]').length).to.equal(1);
-      expect(dom.find('input[name="city"]').length).to.equal(1);
+      const store = createMockStore(storeAnonymous)
+      const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
+      const component = unwrapReduxComponent(context)
+      expect(component.props.user.anonymous).to.be.equal(true)
+      expect(context.find('input[name="name"]').length).to.equal(1);
+      expect(context.find('input[name="email"]').length).to.equal(1);
+      expect(context.find('input[name="address1"]').length).to.equal(1);
+      expect(context.find('input[name="address2"]').length).to.equal(1);
+      expect(context.find('input[name="city"]').length).to.equal(1);
       // not testing state because state is a sub component
-      // expect(dom.find('input[name="state"]').length).to.equal(1);
-      expect(dom.find('input[name="zip"]').length).to.equal(1);
+      // expect(context.find('input[name="state"]').length).to.equal(1);
+      expect(context.find('input[name="zip"]').length).to.equal(1);
     });
 
-    //it('TODO:user fields displaying', () => {});
+    it('petition with user fields displaying', () => {
+      // Note: needs to test when it *appears* not when it's required
+      const store = createMockStore(storeAkid)
+      const context = mount(<SignatureAddForm {...propsProfileOpposite} store={store}/>)
+      const component = unwrapReduxComponent(context)
+      expect(Boolean(component.props.user.anonymous)).to.be.equal(false)
+      expect(context.find('input[name="name"]').length).to.equal(0);
+      expect(context.find('input[name="email"]').length).to.equal(0);
+      expect(context.find('input[name="address1"]').length).to.equal(1);
+      expect(context.find('input[name="address2"]').length).to.equal(1);
+      expect(context.find('input[name="city"]').length).to.equal(1);
+      // not testing state because state is a sub component
+      // expect(context.find('input[name="state"]').length).to.equal(1);
+      expect(context.find('input[name="zip"]').length).to.equal(1);
+    });
 
-    //it('TODO:local petition with user fields displaying', () => {});
+    it('local petition with user fields displaying', () => {
+      const store = createMockStore(storeAkid)
+      const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
+      const component = unwrapReduxComponent(context)
+      expect(Boolean(component.props.user.anonymous)).to.be.equal(false)
+      expect(context.find('input[name="name"]').length).to.equal(0);
+      expect(context.find('input[name="email"]').length).to.equal(0);
+      expect(context.find('input[name="address1"]').length).to.equal(1);
+      expect(context.find('input[name="address2"]').length).to.equal(1);
+      expect(context.find('input[name="city"]').length).to.equal(1);
+      // not testing state because state is a sub component
+      // expect(context.find('input[name="state"]').length).to.equal(1);
+      expect(context.find('input[name="zip"]').length).to.equal(1);
+    });
 
     //it('TODO:local petition without address when user has address', () => {});
 
@@ -74,6 +101,7 @@ describe('<SignatureAddForm />', () => {
   describe('<SignatureAddForm /> stateful tests', () => {
     // it('TODO:non-US address', () => {})
     // it('TODO:logout/unrecognize shows anonymous field list', () => {})
+
     it('checking volunteer requires phone', () => {
       const store = createMockStore(storeAnonymous)
       const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -1,34 +1,90 @@
 import React from 'react';
 import { expect } from 'chai';
 
+import outkastPetition from '../../local/api/v1/petitions/outkast.json'
+import outkastPetition2 from '../../local/api/v1/petitions/outkast-opposite.json'
+
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { createMockStore } from 'redux-test-utils';
 
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { shallowWithStore } from 'enzyme-redux';
+import { unwrapReduxComponent } from '../lib';
 
 import SignatureAddForm from '../../src/components/signature-add-form';
 
 describe('<SignatureAddForm />', () => {
-	it('renders nothing if current is undefined', () => {
-          const expectedState = {userStore: {'signonId': 123}}
-          const props = {
-            'petition': {
-              '_embedded': {
-                'creator': 'hi'
-              }
-            },
-            'query': {}
-          }
-	  const context = shallowWithStore(<SignatureAddForm {...props} />, createMockStore(expectedState))
-	  expect(context.props().user.signonId).to.be.equal(123)
-	});
-        /*
-	it('formats numbers', () => {
-		const context = shallow(<SignatureCount current={1000} goal={1000000}/>);
-		expect(context.find('.progress-current strong').text()).to.equal('1,000');
-		expect(context.find('.progress-goal strong').text()).to.equal('1,000,000');
-	});
-        */
+  const propsProfileBase = { petition: outkastPetition, query: {} }
+  const propsProfileOpposite = { petition: outkastPetition2, query: {} }
+  const propsProfileBaseQueries = { petition: outkastPetition,
+                                    query: { source: 'c.123', mailing_id: '123'} }
+  const propsProfileOppositeQueries = { petition: outkastPetition2,
+                                        query: { source: 'c.123', mailing_id: '123'} }
+  const propsProfileOppositeQueries2 = { petition: outkastPetition2,
+                                         query: { source: 'c.123' } }
+  const storeAnonymous = { userStore: { anonymous: true }}
+  const storeAkid = { userStore: { signonId: 123456,
+                                   token: 'akid:fake.123456.bad123',
+                                   given_name: 'Three Stacks'}}
+  const storeAkidHasAddress = { userStore: { signonId: 123456,
+                                             token: 'akid:fake.123456.bad123',
+                                             given_name: 'Three Stacks',
+                                             postal_addresses: [{status: 'Potential'}]}}
+
+  describe('<SignatureAddForm /> static tests', () => {
+    it('basic loading', () => {
+      const context = shallowWithStore(<SignatureAddForm {...propsProfileBase} />,
+                                       createMockStore(storeAnonymous))
+      expect(context.props().user.anonymous).to.be.equal(true)
+      const dom = context.render()
+      expect(dom.find('#sign-here').text().match(/Sign this petition/)[0]).to.equal('Sign this petition');
+    });
+
+    //it('TODO:anonymous fields displaying', () => {});
+
+    //it('TODO:user fields displaying', () => {});
+
+    //it('TODO:local petition with user fields displaying', () => {});
+
+    //it('TODO:local petition without address when user has address', () => {});
+
+    //it('TODO:show optin warning', () => {});
+
+    //it('TODO:showing optin checkbox', () => {});
+
+    //it('TODO: hidden optin', () => {});
+
+    //it('TODO:non-US address', () => {});
+
+  })
+  describe('<SignatureAddForm /> stateful tests', () => {
+    // it('TODO:non-US address', () => {})
+    // it('TODO:logout/unrecognize shows anonymous field list', () => {})
+    it('TODO:checking volunteer requires phone', () => {
+      const store = createMockStore(storeAnonymous)
+      const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
+      const component = unwrapReduxComponent(context)
+      const reqFieldsBefore = component.updateRequiredFields(true)
+      expect(typeof reqFieldsBefore.phone).to.be.equal('undefined')
+      component.volunteer({target:{checked: true}})
+      expect(component.state.volunteer).to.be.equal(true)
+      const reqFieldsAfter = component.updateRequiredFields(true)
+      expect(typeof reqFieldsAfter.phone).to.be.equal('string')
+
+      component.setState({address1:'123 main', city:'Pittsburgh', state:'PA', name:'John Smith', email:'hi@example.com', zip:'60024'})
+      expect(component.formIsValid()).to.be.equal(false)
+      component.setState({phone: '123-123-1234'})
+      expect(component.formIsValid()).to.be.equal(true)
+    })
+    // it('TODO:typing incomplete fields submit fails and displays validation error messages', () => {})
+    it('TODO:submitting petition gives good data', () => {
+      const store = createMockStore(storeAnonymous)
+      const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
+      const component = unwrapReduxComponent(context)
+
+      component.volunteer({target:{checked: true}})
+      expect(component.state.volunteer).to.be.equal(true)
+    })
+  })
 });

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -15,6 +15,13 @@ import { unwrapReduxComponent } from '../lib';
 import SignatureAddForm from '../../src/components/signature-add-form';
 
 describe('<SignatureAddForm />', () => {
+  // This file is organized into two sub- describe() buckets.
+  // 1. for "static tests" which do not involve any state
+  // 2. for changing state (like filling in forms, etc)
+  // Please put new tests in the appropriate bucket with `it(...)`
+  // Below are a set of profiles and user store states that can be re-used
+  // for different test conditions
+
   const propsProfileBase = { petition: outkastPetition, query: {} }
   const propsProfileOpposite = { petition: outkastPetition2, query: {} }
   const propsProfileBaseQueries = { petition: outkastPetition,
@@ -33,6 +40,8 @@ describe('<SignatureAddForm />', () => {
                                              postal_addresses: [{status: 'Potential'}]}}
 
   describe('<SignatureAddForm /> static tests', () => {
+    //THESE ARE TESTS WHERE NO STATE IS CHANGED -- we send in properties, and the rest should be static
+
     it('basic loading', () => {
       const store = createMockStore(storeAnonymous)
       const context = mount(<SignatureAddForm {...propsProfileBase} store={store}/>)
@@ -99,6 +108,7 @@ describe('<SignatureAddForm />', () => {
 
   })
   describe('<SignatureAddForm /> stateful tests', () => {
+    //THESE ARE TESTS WHERE WE CHANGE THE STATE (FILL IN FORM, ETC)
     // it('TODO:non-US address', () => {})
     // it('TODO:logout/unrecognize shows anonymous field list', () => {})
 

--- a/test/lib.js
+++ b/test/lib.js
@@ -1,0 +1,11 @@
+export const unwrapReduxComponent = (mountedContext) => (
+  // mountedContext will be something like mount(<Foo ... />)
+  // This method gets you the Foo context, unwrapped from its redux and mount wrapper
+
+  // This is pretty hacky, but haven't found a better way to get this.
+  // You can try something like mountedContext.find(Foo).get(0) but
+  // I believe this only returns the redux-wrapped instance.
+  // If you want to unhack this, then instance._reactInternalInstance._debugID
+  // will help.
+  mountedContext.instance()._reactInternalInstance._renderedComponent._instance
+)


### PR DESCRIPTION
This also fixes a few bugs that surfaced when setting the tests up:
* putting the mobile-related headers into our index.html
* removing hard-coded content from the add-form (Donald Trump isn't *always* the petition target :-)
* setting up the component for easier testing