### PR TITLE
thanks-next-petition suggestion component. with some changes to the loadTopPetitions action

### DIFF
--- a/local/api/v1/top-petitions.json
+++ b/local/api/v1/top-petitions.json
@@ -1,1 +1,55 @@
-{"_links":{"url":"http://localhost:8000/api/v1/top-petitions","next":null,"previous":null},"count":1,"page_size":100,"_embedded":[{"_links":{"url":"https://petitions.moveon.org/sign/outkast"},"created_date":"2015-07-15T05:02:12Z","origin_system":"petitions.moveon.org","identifiers":[95983,"list_id:96069"],"name":"outkast","title":"Georgia: Add Outkast to Stone Mountain!","summary":"Carve Big Boi and Andre 3000, riding in a Cadillac, into the face of Stone Mountain.","description":"<p>I believe it&#39;s important to recognize the history and heritage of all Georgians. However, the carving of Davis, Lee, and Jackson on the side of Stone Mountain only represents a small, regrettable time in the history of the Peach State. It&#39;s high time we added a bit more of our history and culture to this monument.</p>\n\n<p>By no means do we wish to erase or destroy the current carving, which, regardless of its context, is an impressive and historic work of art. We simply wish to add new carvings, of  Atlanta hip-hop duo Outkast, to the mountainside. There&#39;s plenty of room.</p>\n\n<p>I believe that Daddy Fat Sacks and Three Stacks should be carved riding in a Cadillac (as is their wont). This will help the new carving blend nicely with the Confederates who are on horseback.</p>\n\n<p>Outkast are two of the greatest Georgians in the history of our state. It&#39;s about time the Empire State of the South paid proper tribute to them, while also improving a great monument and tourist attraction.</p>","target":[{"name":"The GA State Senate"}],"share_options":[{"facebook_share":{"image":"http://s3.moveon.org/images/20150716_outkaststonemountain(1).png","description":"Tell Georgia's legislature: Carve Big Boi and Andre 3000, riding in a Cadillac (as is their wont), into the face of Stone Mountain. Click here to add your name."},"twitter_share":{"message":"Sign&RT: Tell #Georgia: Add #Outkast to #StoneMountain! http://example.com @moveon @BigBoi #StankMountain"}}],"_embedded":{},"total_signatures":1,"status":"Verified","petition_id":95983,"contact_name":"Mack Fooooooo","needs_full_addresses":true,"collect_volunteers":false,"entity":"c4","signature_goal":15000}],"total_pages":1,"page":1,"total_records":1}
+{
+    "_embedded": [
+        {
+            "_embedded": {
+                "creator": {
+                    "name": "Mack Fooooooo"
+                }
+            },
+            "_links": {
+                "url": "https://petitions.moveon.org/sign/outkast"
+            },
+            "collect_volunteers": "Can you help carve it?",
+            "contact_name": "Mack Fooooooo",
+            "created_date": "2015-07-15T05:02:12Z",
+            "description": "<p>I believe it&#39;s important to recognize the history and heritage of all Georgians. However, the carving of Davis, Lee, and Jackson on the side of Stone Mountain only represents a small, regrettable time in the history of the Peach State. It&#39;s high time we added a bit more of our history and culture to this monument.</p>\n\n<p>By no means do we wish to erase or destroy the current carving, which, regardless of its context, is an impressive and historic work of art. We simply wish to add new carvings, of  Atlanta hip-hop duo Outkast, to the mountainside. There&#39;s plenty of room.</p>\n\n<p>I believe that Daddy Fat Sacks and Three Stacks should be carved riding in a Cadillac (as is their wont). This will help the new carving blend nicely with the Confederates who are on horseback.</p>\n\n<p>Outkast are two of the greatest Georgians in the history of our state. It&#39;s about time the Empire State of the South paid proper tribute to them, while also improving a great monument and tourist attraction.</p>",
+            "entity": "c4",
+            "identifiers": [
+                95983,
+                "list_id:96069"
+            ],
+            "name": "outkast",
+            "needs_full_addresses": true,
+            "origin_system": "petitions.moveon.org",
+            "petition_id": 95983,
+            "share_options": [
+                {
+                    "twitter_share": {
+                        "message": "Tell Georgia to add Outkast to Stone Mountain! [URL]"
+                    }
+                }
+            ],
+            "signature_goal": 9999,
+            "status": "Verified",
+            "summary": "Carve Big Boi and Andre 3000, riding in a Cadillac, into the face of Stone Mountain.",
+            "target": [
+                {
+                    "name": "The Georgia State Senate",
+                    "ocd-division": "ocd-division/country:us/state:ga/sldu"
+                }
+            ],
+            "title": "Georgia: Add Outkast to Stone Mountain!",
+            "total_signatures": 2000
+        }
+    ],
+    "_links": {
+        "next": null,
+        "previous": null,
+        "url": "http://localhost:8000/api/v1/top-petitions"
+    },
+    "count": 1,
+    "page": 1,
+    "page_size": 100,
+    "total_pages": 1,
+    "total_records": 1
+}

--- a/local/index.html
+++ b/local/index.html
@@ -9,7 +9,7 @@
   </head>
   <body class="moveon-petitions">
     <div id="root"></div>
-    <script src="https://unpkg.com/react@15.4.1/dist/react.js"></script>
-    <script src="https://unpkg.com/react-dom@15.4.1/dist/react-dom.js"></script>
+    <script src="<%= htmlWebpackPlugin.options.reactJs %>"></script>
+    <script src="<%= htmlWebpackPlugin.options.reactDomJs %>"></script>
   </body>
 </html>

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -78,7 +78,10 @@ export function loadTopPetitions(pac, megapartner, forceReload) {
       topPetitionsKey
     })
     const { userStore, petitionStore } = getState()
-    if (!forceReload && petitionStore.topPetitions[topPetitionsKey]) {
+    if (!forceReload
+        && petitionStore
+        && petitionStore.topPetitions
+        && petitionStore.topPetitions[topPetitionsKey]) {
       return dispatch({
         type: actionTypes.FETCH_TOP_PETITIONS_SUCCESS,
         useCache: true,
@@ -92,7 +95,7 @@ export function loadTopPetitions(pac, megapartner, forceReload) {
     if (megapartner) {
       query.push(`megapartner=${megapartner}`)
     }
-    if (userStore.signonId) {
+    if (userStore && userStore.signonId) {
       query.push(`user=${userStore.signonId}`)
     }
     const queryString = ((query.length) ? `?${query.join('&')}` : '')

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -38,7 +38,10 @@ export function loadPetition(petitionSlug, forceReload) {
       slug: petitionSlug
     })
     const { petitionStore } = getState()
-    if (!forceReload && petitionStore.petitions[petitionSlug]) {
+    if (!forceReload
+        && petitionStore
+        && petitionStore.petitions
+        && petitionStore.petitions[petitionSlug]) {
       return dispatch({
         type: actionTypes.FETCH_PETITION_SUCCESS,
         petition: petitionStore.petitions[petitionSlug],

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -21,7 +21,7 @@ export const actionTypes = {
   PETITION_SIGNATURE_FAILURE: 'PETITION_SIGNATURE_FAILURE'
 }
 
-export function loadPetition(petitionSlug) {
+export function loadPetition(petitionSlug, forceReload) {
   const urlKey = `petitions/${petitionSlug}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
     return (dispatch) => {
@@ -32,11 +32,19 @@ export function loadPetition(petitionSlug) {
       })
     }
   }
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_PETITION_REQUEST,
       slug: petitionSlug
     })
+    const { petitionStore } = getState()
+    if (!forceReload && petitionStore.petitions[petitionSlug]) {
+      return dispatch({
+        type: actionTypes.FETCH_PETITION_SUCCESS,
+        petition: petitionStore.petitions[petitionSlug],
+        slug: petitionSlug
+      })
+    }
     return fetch(`${Config.API_URI}/api/v1/${urlKey}.json`)
       .then(
         (response) => response.json().then((json) => {
@@ -57,40 +65,48 @@ export function loadPetition(petitionSlug) {
   }
 }
 
-export function loadTopPetitions(pac, megapartner) {
-  let urlKey = 'top-petitions'
-  if (pac) {
-    if (megapartner) {
-      urlKey += `?megapartner=${megapartner}&pac=1`
-    } else {
-      urlKey += '?pac=1'
-    }
-  } else if (megapartner) {
-    urlKey += `?megapartner=${megapartner}`
-  }
-
-  return (dispatch) => {
+export function loadTopPetitions(pac, megapartner, forceReload) {
+  // topPetitionsKey must not just be truthily equal but exact
+  // eslint-disable-next-line no-unneeded-ternary
+  const topPetitionsKey = `${pac ? 1 : 0}--${megapartner ? megapartner : ''}`
+  return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_TOP_PETITIONS_REQUEST,
-      pac,
-      megapartner
+      topPetitionsKey
     })
-    return fetch(`${Config.API_URI}/api/v1/${urlKey}.json`)
+    const { userStore, petitionStore } = getState()
+    if (!forceReload && petitionStore.topPetitions[topPetitionsKey]) {
+      return dispatch({
+        type: actionTypes.FETCH_TOP_PETITIONS_SUCCESS,
+        useCache: true,
+        topPetitionsKey
+      })
+    }
+    const query = []
+    if (pac !== null) {
+      query.push(`pac=${pac ? 1 : 0}`)
+    }
+    if (megapartner) {
+      query.push(`megapartner=${megapartner}`)
+    }
+    if (userStore.signonId) {
+      query.push(`user=${userStore.signonId}`)
+    }
+    const queryString = ((query.length) ? `?${query.join('&')}` : '')
+    return fetch(`${Config.API_URI}/api/v1/top-petitions.json${queryString}`)
       .then(
         (response) => response.json().then((json) => {
           dispatch({
             type: actionTypes.FETCH_TOP_PETITIONS_SUCCESS,
             petitions: json._embedded,
-            pac,
-            megapartner
+            topPetitionsKey
           })
         }),
         (err) => {
           dispatch({
             type: actionTypes.FETCH_TOP_PETITIONS_FAILURE,
             error: err,
-            pac,
-            megapartner
+            topPetitionsKey
           })
         }
       )

--- a/src/components/thanks-next-petition.js
+++ b/src/components/thanks-next-petition.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { loadTopPetitions } from '../actions/petitionActions'
+import { connect } from 'react-redux'
+
+/* A nice description of how/when this works from the Platform Team:
+   You have to click on a share link and have that open in another tab.
+   A countdown begins only once you click back into the thanks page tab.
+   It tells you it's going to redirect in x seconds and gives you a link to cancel.
+   If you click the link to cancel, then you stay on the page.
+   If not, you go to the new petition, with the source code share_chain.
+   If you click on another share link, the process will repeat.
+*/
+
+class ThanksNextPetition extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      cancelled: false
+    }
+  }
+
+  componentWillMount() {
+    if (!this.props.nextPetitionsLoaded) {
+      this.props.dispatch(loadTopPetitions(this.props.entity === 'pac'))
+    }
+  }
+
+  render() {
+    if (!this.props.nextPetition || this.state.cancelled) {
+      return null
+    }
+    return (
+      <div className='message-header advancing_message'>
+        We&#39;ve found another petition which may interest you.  We&#39;ll forward you there in <span className='countdown_clock'></span> seconds. [ <a onClick={() => this.setState({ cancelled: true })} className='control_advance_cancel'>cancel</a> ]
+      </div>
+    )
+  }
+}
+
+ThanksNextPetition.propTypes = {
+  dispatch: PropTypes.func,
+  nextPetition: PropTypes.object,
+  nextPetitionsLoaded: PropTypes.bool,
+  entity: PropTypes.string
+}
+
+function mapStateToProps(store) {
+  const { nextPetitionsLoaded, nextPetitions, petitions } = store.petitionStore
+  let nextPetition = null
+  if (nextPetitions && nextPetitions.length && nextPetitions[0]) {
+    nextPetition = petitions[nextPetitions[0]]
+  }
+  return { nextPetition,
+    nextPetitionsLoaded
+  }
+}
+
+export default connect(mapStateToProps)(ThanksNextPetition)

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -25,7 +25,6 @@ class Thanks extends React.Component {
   shareLink(evt) {
     evt.target.select()
     this.recordShare('email', `${this.state.pre}.ln.cp`)
-    this.setState({ sharedSocially: true }) // useful for debugging
   }
 
   shareEmail(evt) {

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { actions as petitionActions } from '../actions/petitionActions.js'
+import { actions as petitionActions } from '../actions/petitionActions'
+import ThanksNextPetition from './thanks-next-petition'
 
 class Thanks extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      pre: 's' // TODO
+      pre: 's', // TODO
+      sharedSocially: false
     }
     this.recordShare = this.recordShare.bind(this)
     this.shareLink = this.shareLink.bind(this)
@@ -22,12 +24,13 @@ class Thanks extends React.Component {
 
   shareLink(evt) {
     evt.target.select()
-    this.recordShareClick('email', `${this.state.pre}.ln.cp`)
+    this.recordShare('email', `${this.state.pre}.ln.cp`)
+    this.setState({ sharedSocially: true }) // useful for debugging
   }
 
   shareEmail(evt) {
     evt.target.select()
-    this.recordShareClick('email', `${this.state.pre}.em.cp`)
+    this.recordShare('email', `${this.state.pre}.em.cp`)
   }
 
   openFacebookSharing(urlToShare) {
@@ -38,6 +41,7 @@ class Thanks extends React.Component {
       fbUrl = `${fbUrl}&r_by=${user.signonId}`
     } // TODO: signatureMessages hash alternative
     window.open(`https://www.facebook.com/share.php?u=${encodeURIComponent(fbUrl)}`)
+    this.setState({ sharedSocially: true })
   }
 
   shareFacebook() {
@@ -45,7 +49,7 @@ class Thanks extends React.Component {
     const shareOpts = (petition.share_options && petition.share_options[0]) || {}
     const self = this
     setTimeout(() => {
-      self.recordShareClick('facebook', `${self.state.pre}.fb`)
+      self.recordShare('facebook', `${self.state.pre}.fb`)
     }, 100)
     let fbUrl = petition._links.url
     if (shareOpts.facebook_share && shareOpts.facebook_share.share_url) {
@@ -66,7 +70,8 @@ class Thanks extends React.Component {
     const encodedValue = encodeURIComponent(this.tweetTextArea.value)
     const url = `http://twitter.com/intent/tweet?text=${encodedValue}`
     window.open(url)
-    this.recordShareClick('twitter', `${this.state.pre}.tw`)
+    this.recordShare('twitter', `${this.state.pre}.tw`)
+    this.setState({ sharedSocially: true })
   }
 
   render() {
@@ -109,6 +114,7 @@ Thanks!
     const copyPasteMessage = `Subject: ${petition.summary}\n\n${mailToMessage}`
 
     return (<div className='row'>
+      {(this.state.sharedSocially ? <ThanksNextPetition entity={petition.entity || ''} /> : null)}
       <div className='span4'>
         <h1 className='size-superxl lh-100 font-lighter'>Thanks!</h1>
       </div>

--- a/src/components/top-petitions.js
+++ b/src/components/top-petitions.js
@@ -42,7 +42,9 @@ TopPetitions.propTypes = {
 const mapStateToProps = (store, ownProps) => {
   const { pac, megapartner } = ownProps
   const topPetitionsState = store.petitionStore.topPetitions
-  const topPetitionsKey = `${pac}--${megapartner}`
+  // topPetitionsKey must not just be truthily equal but exact
+  // eslint-disable-next-line no-unneeded-ternary
+  const topPetitionsKey = `${pac ? 1 : 0}--${megapartner ? megapartner : ''}`
   const topPetitionsProp = (
     typeof topPetitionsState[topPetitionsKey] === 'undefined'
   ) ? false : topPetitionsState[topPetitionsKey].map(petitionId => store.petitionStore.petitions[petitionId])

--- a/src/components/top-petitions.js
+++ b/src/components/top-petitions.js
@@ -15,13 +15,13 @@ class TopPetitions extends React.Component {
   }
 
   render() {
-    const { topPetitions, source } = this.props
+    const { topPetitions, source, fullWidth } = this.props
     const petitionList = (topPetitions) ? topPetitions.map(petition => (
-      <PetitionPreview petition={petition} source={source} />
+      <PetitionPreview key={petition.petition_id} petition={petition} source={source} />
     )) : ''
 
     return (
-      <div id='campaign-widget' className='span6 widget clearfix pull-right'>
+      <div id='campaign-widget' className={fullWidth ? 'span12 widget clearfix' : 'span6 widget clearfix pull-right'}>
         <div className='widget-top'>
           <h3>Hot Petitions</h3>
         </div>
@@ -36,7 +36,8 @@ TopPetitions.propTypes = {
   megapartner: PropTypes.string,
   source: PropTypes.string,
   topPetitions: PropTypes.oneOfType([PropTypes.array, PropTypes.bool]),
-  loadPetitions: PropTypes.func
+  loadPetitions: PropTypes.func,
+  fullWidth: PropTypes.bool
 }
 
 const mapStateToProps = (store, ownProps) => {

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ export const Config = {
   BASE_APP_PATH: process.env.BASE_APP_PATH,
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',
-  USE_HASH_BROWSING: !process.env.PROD
+  USE_HASH_BROWSING: !process.env.PROD,
+  ENTITY: process.env.ENTITY || window.ENTITY
 }
 export default Config

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,19 +1,54 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 
+import { Config } from '../config.js'
 import BillBoard from '../components/billboard'
 import SearchBar from '../components/searchbar'
 import RecentVictoryList from '../components/recentvictory.js'
 import TopPetitions from '../components/top-petitions'
 
-const Home = () => (
-  <div className='container background-moveon-white bump-top-1'>
-    <BillBoard />
-    <SearchBar />
-    <div className='row front-content'>
-      <TopPetitions pac={0} megapartner='' source='homepage' />
-      <RecentVictoryList />
-    </div>
-  </div>
-)
+const Home = ({ params, nav }) => {
+  const { organization } = params
+  const isPac = (organization === 'pac' || Config.ENTITY === 'pac')
+  const isOrganization = Boolean(organization && organization !== 'pac')
+  return (
+    <div className='container background-moveon-white bump-top-1'>
+      {isOrganization ? null : <BillBoard />}
+      <SearchBar />
 
-export default Home
+      {isOrganization
+       ? (
+        <div>
+          <h2>{organization}</h2>
+          {organization} is a
+          <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>
+        </div>
+       ) : null
+      }
+
+      <div className='row front-content'>
+        <TopPetitions
+          pac={isPac ? 1 : 0}
+          megapartner={organization || ''}
+          fullWidth={isOrganization}
+          source='homepage'
+        />
+        {isOrganization ? null : <RecentVictoryList />}
+      </div>
+    </div>
+  )
+}
+
+Home.propTypes = {
+  nav: PropTypes.object,
+  params: PropTypes.object
+}
+
+function mapStateToProps(store) {
+  return {
+    nav: store.navStore
+  }
+}
+
+export default connect(mapStateToProps)(Home)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -18,7 +18,9 @@ const initialPetitionState = {
   petitionSignatures: {}, // keyed by petition slug, then page
   signatureStatus: {}, // keyed by petition_id (because form doesn't have slug)
   signatureMessages: {}, // keyed by petition_id, MessageId value from SQS post
-  topPetitions: {} // lists of petition IDs keyed by pac then megapartner
+  topPetitions: {}, // lists of petition IDs keyed by pac then megapartner
+  nextPetitions: [], // list of petition IDs that can be suggested to sign next
+  nextPetitionsLoaded: false // is nextPetitions empty because there are none to suggest or it hasn't been loaded yet?
 }
 
 const initialUserState = {
@@ -60,7 +62,7 @@ function navReducer(state = navState, action) {
       break
   }
   if (petition) {
-    const creator = petition._embedded && petition._embedded.creator
+    const creator = ((petition._embedded && petition._embedded.creator) || {})
     if (creator.organization_logo_image_url) {
       return Object.assign({}, state, { partnerCobrand: {
         logo: creator.organization_logo_image_url,
@@ -81,12 +83,11 @@ function petitionReducer(state = initialPetitionState, action) {
     page,
     signatures,
     petitions,
-    pac,
-    megapartner
+    topPetitionsKey,
+    useCache
   } = action
   let petition = {}
   let updateData = {}
-  let topPetitionsKey = ''
   if (typeof petitionWithoutSlug === 'object') {
     petition = Object.assign(petitionWithoutSlug, { slug })
   } else if (slug && typeof state.petitions[slug] !== 'undefined') {
@@ -111,6 +112,9 @@ function petitionReducer(state = initialPetitionState, action) {
       if (action.messageId) {
         updateData.signatureMessages = Object.assign(
           {}, state.signatureMessages, { [petition.petition_id]: action.messageId })
+      }
+      if (state.nextPetitionsLoaded) {
+        updateData.nextPetitions = state.nextPetitions.filter(petId => petId !== petition.petition_id)
       }
       return Object.assign({}, state, updateData)
     case petitionActionTypes.FETCH_PETITION_SIGNATURES_SUCCESS:
@@ -138,18 +142,27 @@ function petitionReducer(state = initialPetitionState, action) {
         )
       })
     case petitionActionTypes.FETCH_TOP_PETITIONS_SUCCESS:
-      topPetitionsKey = `${pac}--${megapartner}`
-      return Object.assign({}, state, {
-        petitions: petitions.reduce((addedPetitions, topPetition) => Object.assign(
-          {}, addedPetitions, {
-            [topPetition.name]: topPetition,
-            [topPetition.petition_id]: topPetition
-          }
-        ), state.petitions),
+      if (useCache) {
+        return state
+      }
+      updateData = {
+        petitions: Object.assign({}, state.petitions,
+                                 ...petitions.map((topPetition) => ({
+                                   [topPetition.name]: topPetition,
+                                   [topPetition.petition_id]: topPetition
+                                 }))),
         topPetitions: Object.assign({}, state.topPetitions, {
           [topPetitionsKey]: petitions.map(topPetition => topPetition.petition_id)
-        })
-      })
+        }),
+        nextPetitionsLoaded: true
+      }
+      updateData.nextPetitions = state.nextPetitions.concat(
+        petitions.map(topPetition => topPetition.petition_id)
+      ).filter((petId, i, list) => (
+        i === list.indexOf(petId) // make each item unique on the list
+          && !(petId in state.signatureStatus || updateData.petitions[petId].signed) // exclude signed
+      ))
+      return Object.assign({}, state, updateData)
     default:
       return state
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,10 +20,13 @@ export const routes = (store) => (
     <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
       <IndexRoute component={Home} />
       <Route path='/sign/:petition_slug' component={SignPetition} />
+      <Route path='/:organization/sign/:petition_slug' component={SignPetition} />
       <Route path='/thanks.html' component={ThanksPage} />
       <Route path='/find' component={SearchPage} />
       <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
       <Route path='/create_start.html' component={CreatePetitionPage} />
+      <Route path='/:organization/create_start.html' component={CreatePetitionPage} />
+      <Route path='/:organization/' component={Home} />
     </Route>
   </Router>
 )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,13 @@ var config = {
       staticPath: (process.env.STATIC_ROOT || ''),
       cssPath: (process.env.NODE_ENV == 'production'
                 ? 'https://s3.amazonaws.com/mop-static/css/moui.css'
-                : '/css/moui.css')
+                : '/css/moui.css'),
+      reactJs: (process.env.LOCAL_REACT
+                ? process.env.LOCAL_REACT + 'react.js'
+                : 'https://unpkg.com/react@15.4.1/dist/react.js'),
+      reactDomJs: (process.env.LOCAL_REACT
+                   ? process.env.LOCAL_REACT + 'react-dom.js'
+                   : 'https://unpkg.com/react-dom@15.4.1/dist/react-dom.js')
     }),
     ((process.env.PROD)
      ? new webpack.optimize.UglifyJsPlugin({sourceMap: true})


### PR DESCRIPTION
random reflection: This semi-dodges the 'pop an item to a queue' challenge.  We depend on petitionStore.nextPetitions getting filtered out by things that are marked within state or frrom the api as signed.  Then it's just the next in that queue.

It also depends on backend changes in https://github.com/MoveOnOrg/mop/pull/58