### PR TITLE
load organization data for organization imbued urls

### DIFF
--- a/docs/HOWTO-write-tests.md
+++ b/docs/HOWTO-write-tests.md
@@ -48,6 +48,8 @@ it('something with redux state', () => {
 });
 ```
 
+A good example of this is `components/signature-add-form.js`
+
 ### A component with children that have redux state
 
 Because Redux does some 'magic'-like stuff to propagate down the `store` property at the
@@ -71,3 +73,12 @@ it('something with children with redux state', () => {
 });
 
 ```
+
+A good example of this is `pages/home.js`
+
+### Gotchas
+
+If you have code that assumes initial store state that isn't reflected
+in your test mock store, then nothing will 'automatically' initialize
+the default state -- you must include any state the code relies on
+including initial state in the test mock store.

--- a/local/api/v1/organizations/mop.json
+++ b/local/api/v1/organizations/mop.json
@@ -1,0 +1,10 @@
+{
+    "_links": {
+        "url": "https://petitions.moveon.org/organization/"
+    },
+    "browser_url": "/mop/",
+    "description": "M.O.P. is short for Mash Out Posse, or is it MoveOn Petitions or.....",
+    "logo_image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mop-04-mika.jpg/220px-Mop-04-mika.jpg",
+    "name": "mop",
+    "organization": "M.O.P."
+}

--- a/local/api/v1/petitions/outkast-opposite.json
+++ b/local/api/v1/petitions/outkast-opposite.json
@@ -6,8 +6,8 @@
       "creator": {
         "name": "Shake it",
         "organization": "M.O.P.",
-        "organization_logo_image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mop-04-mika.jpg/220px-Mop-04-mika.jpg",
-        "organization_url": "https://en.wikipedia.org/wiki/M.O.P.",
+        "logo_image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Mop-04-mika.jpg/220px-Mop-04-mika.jpg",
+        "browser_url": "https://en.wikipedia.org/wiki/M.O.P.",
         "custom_fields": {
           "may_optin": true
         }

--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -1,0 +1,56 @@
+import 'whatwg-fetch'
+
+import Config from '../config.js'
+
+export const actionTypes = {
+  FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
+  FETCH_ORG_SUCCESS: 'FETCH_ORG_SUCCESS',
+  FETCH_ORG_FAILURE: 'FETCH_ORG_FAILURE'
+}
+
+export function loadOrganization(orgSlug, forceReload) {
+  const urlKey = `organizations/${orgSlug}`
+  if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
+    return (dispatch) => {
+      dispatch({
+        type: actionTypes.FETCH_ORG_SUCCESS,
+        org: window.preloadObjects[urlKey],
+        slug: orgSlug
+      })
+    }
+  }
+  return (dispatch, getState) => {
+    dispatch({
+      type: actionTypes.FETCH_ORG_REQUEST,
+      slug: orgSlug
+    })
+    const { navStore } = getState()
+    if (!forceReload
+        && navStore
+        && navStore.orgs
+        && navStore.orgs[orgSlug]) {
+      return dispatch({
+        type: actionTypes.FETCH_ORG_SUCCESS,
+        org: navStore.orgs[orgSlug],
+        slug: orgSlug
+      })
+    }
+    return fetch(`${Config.API_URI}/api/v1/${urlKey}.json`)
+      .then(
+        (response) => response.json().then((json) => {
+          dispatch({
+            type: actionTypes.FETCH_ORG_SUCCESS,
+            org: json,
+            slug: json.name || orgSlug
+          })
+        }),
+        (err) => {
+          dispatch({
+            type: actionTypes.FETCH_ORG_FAILURE,
+            error: err,
+            slug: orgSlug
+          })
+        }
+      )
+  }
+}

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -47,7 +47,9 @@ export function loadTokenSession(tokens) {
       .map((k) => ((tokens[k]) ? `${encodeURIComponent(k)}=${encodeURIComponent(tokens[k])}` : ''))
       .join('&')
     const queryString = (args && args !== '&') ? `?${args}` : ''
-    fetch(`${Config.API_URI}/api/v1/user/session.json${queryString}`)
+    fetch(`${Config.API_URI}/api/v1/user/session.json${queryString}`, {
+      credentials: 'include'
+    })
     .then(
       (response) => response.json().then((json) => {
         dispatch({

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -4,7 +4,9 @@ import { connect } from 'react-redux'
 
 import NavLink from './nav-link'
 
-const Nav = ({ user, nav }) => {
+const Nav = ({ user, nav, organization }) => {
+  const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
+
   const userLinks = (
     <div className='pull-right bump-top-1 span-7 top-menu'>
       <ul className='nav collapse nav-collapse'>
@@ -36,8 +38,8 @@ const Nav = ({ user, nav }) => {
   )
 
   const partnerLogoLinks = (
-    (nav.partnerCobrand)
-      ? (<a href={nav.partnerCobrand.url}><img className='org_logo' src={nav.partnerCobrand.logo} alt={nav.partnerCobrand.name} /></a>
+    (cobrand)
+      ? (<a href={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></a>
         ) : null)
 
   return (
@@ -88,7 +90,8 @@ const Nav = ({ user, nav }) => {
 
 Nav.propTypes = {
   user: PropTypes.object,
-  nav: PropTypes.object
+  nav: PropTypes.object,
+  organization: PropTypes.string
 }
 
 function mapStateToProps(store) {

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types'
 import Nav from './nav.js'
 import Footer from './footer.js'
 
-const Wrapper = ({ children }) => (
+const Wrapper = ({ children, params }) => (
   <div>
-    <Nav />
+    <Nav organization={params && params.organization || ''} />
     <main className='main'>
       {children}
     </main>
@@ -16,8 +16,10 @@ const Wrapper = ({ children }) => (
   </div>
 )
 
+
 Wrapper.propTypes = {
-  children: PropTypes.object.isRequired
+  children: PropTypes.object.isRequired,
+  params: PropTypes.object
 }
 
 export default Wrapper

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -8,10 +8,11 @@ import SearchBar from '../components/searchbar'
 import RecentVictoryList from '../components/recentvictory.js'
 import TopPetitions from '../components/top-petitions'
 
-const Home = ({ params }) => {
+const Home = ({ params, nav }) => {
   const { organization } = params
-  const isPac = (organization === 'pac' || Config.ENTITY === 'pac')
   const isOrganization = Boolean(organization && organization !== 'pac')
+  const isPac = (organization === 'pac' || (!isOrganization && Config.ENTITY === 'pac'))
+  const orgData = (nav && nav.orgs && nav.orgs[organization]) || {}
   return (
     <div className='container background-moveon-white bump-top-1'>
       {isOrganization ? null : <BillBoard />}
@@ -20,8 +21,8 @@ const Home = ({ params }) => {
       {isOrganization
        ? (
         <div>
-          <h2>{organization}</h2>
-          {organization} is a
+          <h2>{orgData.organization}</h2>
+          {orgData.description || `${orgData.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
           <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>
         </div>
        ) : null

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -20,7 +20,7 @@ const Home = ({ params, nav }) => {
 
       {isOrganization
        ? (
-        <div>
+        <div className='organization-header'>
           <h2>{orgData.organization}</h2>
           {orgData.description || `${orgData.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
           <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import { actionTypes as navActionTypes } from '../actions/navActions.js'
 import { actionTypes as petitionActionTypes } from '../actions/petitionActions.js'
 import { actionTypes as sessionActionTypes } from '../actions/sessionActions.js'
 
@@ -10,7 +11,8 @@ import { actionTypes as sessionActionTypes } from '../actions/sessionActions.js'
 // }
 
 const navState = {
-  partnerCobrand: null // or {logo, link, name}
+  partnerCobrand: null, // or {logo, link, name}
+  orgs: {} // organization data by organization slug
 }
 
 const initialPetitionState = {
@@ -52,6 +54,10 @@ function navReducer(state = navState, action) {
   // rather than the actions being pure 'model' interfaces
   let petition = null
   switch (action.type) {
+    case navActionTypes.FETCH_ORG_SUCCESS:
+      return Object.assign({}, {
+        orgs: Object.assign({}, state.orgs, { [action.slug]: action.org })
+      })
     case petitionActionTypes.FETCH_PETITION_SUCCESS:
       petition = action.petition
       break
@@ -62,12 +68,12 @@ function navReducer(state = navState, action) {
       break
   }
   if (petition) {
-    const creator = ((petition._embedded && petition._embedded.creator) || {})
-    if (creator.organization_logo_image_url) {
+    const sponsor = ((petition._embedded && (petition._embedded.sponsor || petition._embedded.creator) || {}))
+    if (sponsor.logo_image_url) {
       return Object.assign({}, state, { partnerCobrand: {
-        logo: creator.organization_logo_image_url,
-        name: creator.organization,
-        url: creator.organization_url
+        logo_image_url: sponsor.logo_image_url,
+        organization: sponsor.organization,
+        browser_url: sponsor.browser_url
       } })
     } // else
     return Object.assign({}, state, { partnerCobrand: null })

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import { IndexRoute, Route, Router, browserHistory, hashHistory } from 'react-ro
 
 import { Config } from './config.js'
 import { loadSession } from './actions/sessionActions.js'
+import { loadOrganization } from './actions/navActions.js'
 import Home from './pages/home.js'
 import SignPetition from './pages/sign-petition.js'
 import ThanksPage from './pages/thanks.js'
@@ -15,18 +16,26 @@ const baseAppPath = process.env.BASE_APP_PATH || '/'
 
 export const appLocation = (Config.USE_HASH_BROWSING ? hashHistory : browserHistory)
 
-export const routes = (store) => (
-  <Router history={appLocation}>
-    <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
-      <IndexRoute component={Home} />
-      <Route path='/sign/:petition_slug' component={SignPetition} />
-      <Route path='/:organization/sign/:petition_slug' component={SignPetition} />
-      <Route path='/thanks.html' component={ThanksPage} />
-      <Route path='/find' component={SearchPage} />
-      <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
-      <Route path='/create_start.html' component={CreatePetitionPage} />
-      <Route path='/:organization/create_start.html' component={CreatePetitionPage} />
-      <Route path='/:organization/' component={Home} />
-    </Route>
-  </Router>
-)
+export const routes = (store) => {
+  const orgLoader = (nextState) => {
+    if (nextState.params && nextState.params.organization) {
+      store.dispatch(loadOrganization(nextState.params.organization))
+    }
+  }
+  return (
+    <Router history={appLocation}>
+      <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
+        <IndexRoute component={Home} />
+        <Route path='/sign/:petition_slug' component={SignPetition} />
+        <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
+        <Route path='/thanks.html' component={ThanksPage} />
+        <Route path='/:organization/thanks.html' component={ThanksPage} onEnter={orgLoader} />
+        <Route path='/find' component={SearchPage} />
+        <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
+        <Route path='/create_start.html' component={CreatePetitionPage} />
+        <Route path='/:organization/create_start.html' component={CreatePetitionPage} onEnter={orgLoader} />
+        <Route path='/:organization/' component={Home} onEnter={orgLoader} />
+      </Route>
+    </Router>
+  )
+}

--- a/test/pages/home.js
+++ b/test/pages/home.js
@@ -8,11 +8,19 @@ import { createMockStore } from 'redux-test-utils'
 import Home from '../../src/pages/home'
 import BillBoard from '../../src/components/billboard'
 import SearchBar from '../../src/components/searchbar'
-import RecentVictoryList from '../../src/components/recentvictory.js'
+import RecentVictoryList from '../../src/components/recentvictory'
+import TopPetitions from '../../src/components/top-petitions'
 
 
 describe('<Home />', () => {
   const baseStore = createMockStore({ navStore: {}, petitionStore: {} })
+  const orgStore = createMockStore({ navStore: { orgs: {
+    mop: {
+      organization: 'M.O.P.',
+      description: 'MOP stands for Mash Out Posse or MoveOn Petitions or ....',
+      logo_image_url: 'https://example.com/mopimage.jpg'
+    }
+  } }, petitionStore: {} })
   it('renders a billboard', () => {
     const myComponent = <Home params={{}} />
     const context = mount(<Provider store={baseStore} children={myComponent} />)
@@ -29,5 +37,15 @@ describe('<Home />', () => {
     const myComponent = <Home params={{}} />
     const context = mount(<Provider store={baseStore} children={myComponent} />)
     expect(context.find('.front-content').find(RecentVictoryList)).to.have.length(1)
+  })
+
+  it('renders org content', () => {
+    const myComponent = <Home params={{ organization: 'mop' }} />
+    const context = mount(<Provider store={orgStore} children={myComponent} />)
+    const orgHeader = context.find('.organization-header')
+    expect(orgHeader).to.have.length(1)
+    expect(orgHeader.find('h2').text()).to.be.equal('M.O.P.')
+    expect(context.find(TopPetitions).props().pac).to.be.equal(0)
+    expect(context.find(TopPetitions).props().megapartner).to.be.equal('mop')
   })
 })


### PR DESCRIPTION
This addresses the last part and completes #69 -- hitting the organization api to get the org data.
There are further tests to add --maybe especially for nav.
There will be more org work esp for supporting orgs within all the other url contexts (sign/thanks/etc)