### PR TITLE
add shorturls for twitter on thanks page and infrastructure for that (/p/ shortcode urls)

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -151,16 +151,17 @@ export function signPetition(petitionSignature, petition, options) {
     })
 
     const completion = (data) => {
-      const finalDispatch = (text) => {
+      const finalDispatch = (json) => {
         const dispatchData = {
           type: actionTypes.PETITION_SIGNATURE_SUCCESS,
           petition,
           signature: petitionSignature
         }
-        if (text) {
-          const sqsResponse = text.match(/<MessageId>(.*)<\/MessageId>/)
+        if (json && json.SendMessageResponse) {
+          const sqsResponse = json.SendMessageResponse.SendMessageResult
           if (sqsResponse) {
-            dispatchData.messageId = sqsResponse[1]
+            dispatchData.messageId = sqsResponse.MessageId
+            dispatchData.messageMd5 = sqsResponse.MD5OfMessageBody
           }
         }
         const dispatchResult = dispatch(dispatchData)
@@ -168,8 +169,8 @@ export function signPetition(petitionSignature, petition, options) {
           registerSignatureAndThanks(dispatchResult.petition)(dispatch)
         }
       }
-      if (data && typeof data.text === 'function') {
-        data.text().then(finalDispatch)
+      if (data && typeof data.json === 'function') {
+        data.json().then(finalDispatch, finalDispatch)
       } else {
         finalDispatch()
       }

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ export const Config = {
   API_WRITABLE: process.env.API_WRITABLE,
   API_SIGN_PETITION: process.env.API_SIGN_PETITION || '',
   BASE_APP_PATH: process.env.BASE_APP_PATH,
+  BASE_URL: process.env.BASE_URL || '',
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',
   USE_HASH_BROWSING: !process.env.PROD,

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React from 'react' // needed to get JSX in scope for text2paraJsx
+import Config from './config'
 
-const formatDate = (date) => {
+export const formatDate = (date) => {
   const monthAbbr = [
     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
@@ -11,9 +12,9 @@ const formatDate = (date) => {
   return `${monthAbbr[monthIndex]} ${day}, ${year}`
 }
 
-const text2paras = (str) => str.split(/\n+/)
+export const text2paras = (str) => str.split(/\n+/)
 
-const ellipsize = (str, length) => {
+export const ellipsize = (str, length) => {
   const re = new RegExp(`^(.{0,${length}})(\\s|$)`)
   const match = String(str).substr(0, length + 1).match(re)
   if (!match) {
@@ -27,7 +28,7 @@ const ellipsize = (str, length) => {
   return match[1]
 }
 
-const text2paraJsx = (str) => {
+export const text2paraJsx = (str) => {
   const paras = text2paras(str)
   return paras.map((paragraph, i) => {
     const paragraphKey = `p${i}`
@@ -37,9 +38,10 @@ const text2paraJsx = (str) => {
   })
 }
 
-const moNumber2base62 = (num) => {
+export const moNumber2base62 = (num) => {
   // This converts a number to base62, and will be used to generate petition redirect urls
   // example: 125962 => 'pju'
+  // See petitionShortCode() below
   const base62 = 'BCDFoHJKLMNPQRSTVWXYZAEIOU012345p789aeiGubcdfghjklzn6qrstvwxym'
   const char62s = []
   let numLeft = num
@@ -51,10 +53,31 @@ const moNumber2base62 = (num) => {
   return char62s.reverse().join('')
 }
 
-export {
-  ellipsize,
-  formatDate,
-  text2paras,
-  text2paraJsx,
-  moNumber2base62
+export const md5ToToken = (responseMd5) => (
+  moNumber2base62(parseInt(responseMd5.slice(0, 12), 16))
+)
+
+export const petitionShortCode = (mode, petitionId, userId, responseMd5) => {
+  // Returns a url that will redirect to the petition that
+  // tracks the userId of the sharer along with the mode of sharing (e.g. twitter/email)
+  // mirrors server-part petitions/petition_shortcode.py
+  const codeParts = [((userId) ? mode : mode.toUpperCase())]
+  const petitionCode = moNumber2base62(parseInt(petitionId, 10))
+  codeParts.push(petitionCode)
+  let ident = userId
+  if (!userId) {
+    if (responseMd5) {
+      // This takes the first 12 chars of the md5 body, parses it from the hex,
+      // and then, even as a really big number, we'll crush it into our base62
+      // the server saves this token in signing, so we can match them up
+      // later.  Note that we are in a 16^12 number space, so we have a LOT
+      // of room even with millions of signatures to make a collision unlikely.
+      ident = parseInt(responseMd5.slice(0, 12), 16)
+    }
+  }
+  if (ident) {
+    codeParts.push(moNumber2base62(parseInt(ident, 10)))
+  }
+  const shortCode = codeParts.join('_')
+  return `${Config.BASE_URL}/p/${shortCode}`
 }

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -27,8 +27,12 @@ class ThanksPage extends React.Component {
     return (
       <div>
         {(this.Thanks && this.props.petition ?
-          <this.Thanks petition={this.props.petition} user={this.props.user} /> :
-          ''
+          <this.Thanks
+            petition={this.props.petition}
+            user={this.props.user}
+            signatureMessage={this.props.signatureMessage}
+          />
+          : ''
         )}
       </div>
     )
@@ -39,15 +43,18 @@ class ThanksPage extends React.Component {
 ThanksPage.propTypes = {
   petition: PropTypes.object,
   user: PropTypes.object,
+  signatureMessage: PropTypes.object,
   location: PropTypes.object,
   dispatch: PropTypes.func
 }
 
 function mapStateToProps(store, ownProps) {
   const pkey = ownProps.location.query.name || ownProps.location.query.petition_id
+  const petition = pkey && store.petitionStore.petitions[pkey]
   return {
-    petition: pkey && store.petitionStore.petitions[pkey],
-    user: store.userStore
+    petition,
+    user: store.userStore,
+    signatureMessage: petition.petition_id && store.signatureMessages[petition.petition_id]
   }
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -19,7 +19,7 @@ const initialPetitionState = {
   petitions: {}, // keyed by slug AND petition_id for petition route
   petitionSignatures: {}, // keyed by petition slug, then page
   signatureStatus: {}, // keyed by petition_id (because form doesn't have slug)
-  signatureMessages: {}, // keyed by petition_id, MessageId value from SQS post
+  signatureMessages: {}, // keyed by petition_id, {messageId, messageMd5} values from SQS post
   topPetitions: {}, // lists of petition IDs keyed by pac then megapartner
   nextPetitions: [], // list of petition IDs that can be suggested to sign next
   nextPetitionsLoaded: false // is nextPetitions empty because there are none to suggest or it hasn't been loaded yet?
@@ -117,7 +117,8 @@ function petitionReducer(state = initialPetitionState, action) {
       }
       if (action.messageId) {
         updateData.signatureMessages = Object.assign(
-          {}, state.signatureMessages, { [petition.petition_id]: action.messageId })
+          {}, state.signatureMessages,
+          { [petition.petition_id]: { messageId: action.messageId, messageMd5: action.messageMd5 } })
       }
       if (state.nextPetitionsLoaded) {
         updateData.nextPetitions = state.nextPetitions.filter(petId => petId !== petition.petition_id)

--- a/test/components/thanks.js
+++ b/test/components/thanks.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { expect } from 'chai'
+
+import { shallow } from 'enzyme'
+
+import Thanks from '../../src/components/thanks'
+
+import outkastPetition from '../../local/api/v1/petitions/outkast.json'
+
+describe('<Thanks />', () => {
+  it('renders thanks for petition', () => {
+    const context = shallow(<Thanks petition={outkastPetition} />)
+    // console.log(context.html())
+    expect(context.find('h1').text()).to.equal('Thanks!')
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,7 @@ var config = {
         'API_WRITABLE': JSON.stringify(process.env.API_WRITABLE || process.env.PROD),
         'API_SIGN_PETITION': JSON.stringify(process.env.API_SIGN_PETITION || ''),
         'BASE_APP_PATH': JSON.stringify(process.env.BASE_APP_PATH || '/'),
+        'BASE_URL': JSON.stringify(process.env.BASE_URL || 'https://petitions.moveon.org'),
         'SESSION_COOKIE_NAME': JSON.stringify(process.env.SESSION_COOKIE_NAME || 'SO_SESSION'),
         'STATIC_ROOT': JSON.stringify(process.env.STATIC_ROOT || ''),
         'TRACK_SHARE_URL': JSON.stringify(process.env.TRACK_SHARE_URL || ''),


### PR DESCRIPTION
This continues work on things that happen when someone signs a petition.
* They get a thank-you email
* on the thanks page, they are offered a short url to share on twitter.  Because in the new system, the react frontend won't have the user_id yet, we need a different kind of short url that we can match up to their signature later, when someone signs from their shared link.  That was architected a while ago with petitions/petition_shortcode.py work, however I didn't finish connecting all the pieces.  Because that short url also needs to exist in the email, this PR also connects more of those pieces.  It also finally decides HOW to construct that token and where to store it -- RateLimit.token and based on the SQS md5 hash of the body (which conveniently will also detect identical content submissions across requests)