### PR TITLE
add a devtips stub and remove capitalized-comments lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,9 +2,12 @@ module.exports = {
   extends: 'airbnb',
   parser: 'babel-eslint',
   rules: {
-    'semi': ['error', 'never'],
+    semi: ['error', 'never'],
     'comma-dangle': ['error', 'never'],
-    'capitalized-comments': ["error", 'never'],
+    'capitalized-comments': ['error', 'always', {
+      ignorePattern: '.*',
+      ignoreInlineComments: true
+    }],
     'no-underscore-dangle': ['off'],
     'no-alert': ['off'],
     'jsx-quotes': ['error', 'prefer-single'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,9 @@ module.exports = {
   extends: 'airbnb',
   parser: 'babel-eslint',
   rules: {
-    semi: ['error', 'never'],
+    'semi': ['error', 'never'],
     'comma-dangle': ['error', 'never'],
+    'capitalized-comments': ["error", 'never'],
     'no-underscore-dangle': ['off'],
     'no-alert': ['off'],
     'jsx-quotes': ['error', 'prefer-single'],

--- a/docs/HOWTO-developer-tips.md
+++ b/docs/HOWTO-developer-tips.md
@@ -1,0 +1,5 @@
+## React in the browser
+
+* Install the React inspector plugin
+* You can get to the global store state with `window.$r.props.store.getState()`
+


### PR DESCRIPTION
After seeing bad things happen in a PR (commented out code got upper-cased), I would like to remove the auto-capitlize lint.
This also has a stub dev doc, so I can remember how to get react redux store state. 