### PR TITLE
fix user session info

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -6,9 +6,7 @@ export const actionTypes = {
   ANONYMOUS_SESSION_START: 'ANONYMOUS_SESSION_START',
   UNRECOGNIZE_USER_SESSION: 'UNRECOGNIZE_USER_SESSION',
   USER_SESSION_START: 'USER_SESSION_START',
-  USER_SESSION_FAILURE: 'USER_SESSION_FAILURE',
-  TOKEN_SESSION_START: 'TOKEN_SESSION_START',
-  TOKEN_SESSION_FAILURE: 'TOKEN_SESSION_FAILURE'
+  USER_SESSION_FAILURE: 'USER_SESSION_FAILURE'
 }
 
 export function unRecognize() {
@@ -19,29 +17,7 @@ export function unRecognize() {
   }
 }
 
-export function loadUserSession() {
-  return (dispatch) => {
-    fetch(`${Config.API_URI}/api/v1/user/session.json`, {
-      credentials: 'include'
-    })
-    .then(
-      (response) => response.json().then((json) => {
-        dispatch({
-          type: actionTypes.USER_SESSION_START,
-          session: json
-        })
-      }),
-      (err) => {
-        dispatch({
-          type: actionTypes.USER_SESSION_FAILURE,
-          error: err
-        })
-      }
-    )
-  }
-}
-
-export function loadTokenSession(tokens) {
+function callSessionApi(tokens) {
   return (dispatch) => {
     const args = Object.keys(tokens)
       .map((k) => ((tokens[k]) ? `${encodeURIComponent(k)}=${encodeURIComponent(tokens[k])}` : ''))
@@ -53,14 +29,14 @@ export function loadTokenSession(tokens) {
     .then(
       (response) => response.json().then((json) => {
         dispatch({
-          type: actionTypes.TOKEN_SESSION_START,
+          type: actionTypes.USER_SESSION_START,
           session: json,
           tokens
         })
       }),
       (err) => {
         dispatch({
-          type: actionTypes.TOKEN_SESSION_FAILURE,
+          type: actionTypes.USER_SESSION_FAILURE,
           error: err,
           tokens
         })
@@ -70,13 +46,14 @@ export function loadTokenSession(tokens) {
 }
 
 export const loadSession = ({ location }) => {
-  // called straigt from top route onEnter, so it's done only once on first-load
+  // Called straigt from top route onEnter, so it's done only once on first-load
+
+  // A cookie doesn't actually indicate authenticated -- we just mark the session differently
   const cookie = String(document.cookie).match(new RegExp(`${Config.SESSION_COOKIE_NAME}=([^;]+)`))
 
-  if (cookie) {
-    return loadUserSession()
-  } else if (location && location.query
-             && (location.query.akid || location.query.id)) {
+  if (cookie
+      || (location && location.query
+          && (location.query.akid || location.query.id))) {
     const tokens = {}
     if (location.query.akid) {
       tokens.akid = location.query.akid
@@ -84,8 +61,9 @@ export const loadSession = ({ location }) => {
     if (location.query.id) {
       tokens.hashedId = location.query.id
     }
-    return loadTokenSession(tokens)
+    return callSessionApi(tokens)
   }
+  // If there was no cookie or tokens, we don't even need to call the api
   return (dispatch) => {
     dispatch({
       type: actionTypes.ANONYMOUS_SESSION_START
@@ -93,10 +71,7 @@ export const loadSession = ({ location }) => {
   }
 }
 
-
 export const actions = {
   unRecognize,
-  loadTokenSession,
-  loadUserSession,
   loadSession
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -226,7 +226,7 @@ function userReducer(state = initialUserState, action) {
       return Object.assign({}, state, newData)
     case sessionActionTypes.USER_SESSION_START:
       if (action.session) {
-        // This should cover any of: given_name, last_name, full_name, etc
+        // session might have: given_name, authenticated, postal_addresses
         Object.assign(newData, action.session)
         const { identifiers } = action.session
         if (identifiers && identifiers.length) {


### PR DESCRIPTION
After implementing the backend, this resolves some bugs/issues with the original implementation of session api and user state.

* We previously separated cookie loading vs. token loading.  Since a cookie doesn't actually indicate authenticated state, we need to combine them.
* Combining them makes the `TOKEN_SESSION_*` and `USER_SESSION_*` a bit redundant so we collapse them
* signature-add-form assumes if someone is identified then there's a `user.token` but we never implemented that (useful) simplification.  This does that based on parameters from the location and/or the session api data. 