### PR TITLE
Nav selectors

### DIFF
--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -1,6 +1,8 @@
 import 'whatwg-fetch'
+import { navOrg } from '../selectors/nav'
 
 import Config from '../config.js'
+
 
 export const actionTypes = {
   FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
@@ -8,31 +10,30 @@ export const actionTypes = {
   FETCH_ORG_FAILURE: 'FETCH_ORG_FAILURE'
 }
 
-export function loadOrganization(orgSlug, forceReload) {
-  const urlKey = `organizations/${orgSlug}`
+export function loadOrganization(slug, forceReload) {
+  const urlKey = `organizations/${slug}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
     return (dispatch) => {
       dispatch({
         type: actionTypes.FETCH_ORG_SUCCESS,
         org: window.preloadObjects[urlKey],
-        slug: orgSlug
+        slug
       })
     }
   }
   return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_ORG_REQUEST,
-      slug: orgSlug
+      slug
     })
-    const { navStore } = getState()
-    if (!forceReload
-        && navStore
-        && navStore.orgs
-        && navStore.orgs[orgSlug]) {
+    const state = getState()
+    const org = navOrg(state, slug)
+
+    if (!forceReload && org) {
       return dispatch({
         type: actionTypes.FETCH_ORG_SUCCESS,
-        org: navStore.orgs[orgSlug],
-        slug: orgSlug
+        org,
+        slug
       })
     }
     return fetch(`${Config.API_URI}/api/v1/${urlKey}.json`)
@@ -41,14 +42,14 @@ export function loadOrganization(orgSlug, forceReload) {
           dispatch({
             type: actionTypes.FETCH_ORG_SUCCESS,
             org: json,
-            slug: json.name || orgSlug
+            slug: json.name || slug
           })
         }),
         (err) => {
           dispatch({
             type: actionTypes.FETCH_ORG_FAILURE,
             error: err,
-            slug: orgSlug
+            slug
           })
         }
       )

--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -3,7 +3,6 @@ import { navOrg } from '../selectors/nav'
 
 import Config from '../config.js'
 
-
 export const actionTypes = {
   FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
   FETCH_ORG_SUCCESS: 'FETCH_ORG_SUCCESS',

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { orgCobrand } from '../selectors/nav'
 
 import NavLink from './nav-link'
 
-const Nav = ({ user, nav, organization }) => {
-  const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
-
+const Nav = ({ user, cobrand }) => {
   const userLinks = (
     <div className='pull-right bump-top-1 span-7 top-menu'>
       <ul className='nav collapse nav-collapse'>
@@ -30,17 +29,21 @@ const Nav = ({ user, nav, organization }) => {
   )
 
   const userDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</a>
+    <a
+      className='icon-link-narrow icon-managepetitions'
+      href='https://petitions.moveon.org/dashboard.html?source=topnav'
+    > {`${user.given_name}’s`} Dashboard</a>
   )
 
   const guestDashboardLink = (
     <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'>Manage Petitions</a>
   )
 
-  const partnerLogoLinks = (
-    (cobrand)
-      ? (<a href={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></a>
-        ) : null)
+  const partnerLogoLinks = cobrand && (
+    <a href={cobrand.browser_url}>
+      <img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} />
+    </a>
+  )
 
   return (
     <div>
@@ -90,14 +93,14 @@ const Nav = ({ user, nav, organization }) => {
 
 Nav.propTypes = {
   user: PropTypes.object,
-  nav: PropTypes.object,
+  cobrand: PropTypes.object,
   organization: PropTypes.string
 }
 
-function mapStateToProps(store) {
+function mapStateToProps(state, ownProps) {
   return {
-    user: store.userStore,
-    nav: store.navStore
+    user: state.userStore,
+    cobrand: orgCobrand(state, ownProps.organization)
   }
 }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -2,17 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { navOrg } from '../selectors/nav'
 import { Config } from '../config.js'
 import BillBoard from '../components/billboard'
 import SearchBar from '../components/searchbar'
 import RecentVictoryList from '../components/recentvictory.js'
 import TopPetitions from '../components/top-petitions'
 
-const Home = ({ params, nav }) => {
+const Home = ({ params, org }) => {
   const { organization } = params
   const isOrganization = Boolean(organization && organization !== 'pac')
   const isPac = (organization === 'pac' || (!isOrganization && Config.ENTITY === 'pac'))
-  const orgData = (nav && nav.orgs && nav.orgs[organization]) || {}
   return (
     <div className='moveon-petitions container background-moveon-white bump-top-1'>
       {isOrganization ? null : <BillBoard />}
@@ -21,8 +21,8 @@ const Home = ({ params, nav }) => {
       {isOrganization
        ? (
         <div className='organization-header'>
-          <h2>{orgData.organization}</h2>
-          {orgData.description || `${orgData.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
+          <h2>{org.organization}</h2>
+          {org.description || `${org.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
           <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>
         </div>
        ) : null
@@ -42,13 +42,13 @@ const Home = ({ params, nav }) => {
 }
 
 Home.propTypes = {
-  nav: PropTypes.object,
+  org: PropTypes.object,
   params: PropTypes.object
 }
 
-function mapStateToProps(store) {
+function mapStateToProps(state, ownProps) {
   return {
-    nav: store.navStore
+    org: navOrg(state, ownProps.params.organization)
   }
 }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -46,9 +46,13 @@ Home.propTypes = {
   params: PropTypes.object
 }
 
+Home.defaultProps = {
+  params: {}
+}
+
 function mapStateToProps(state, ownProps) {
   return {
-    org: navOrg(state, ownProps.params.organization)
+    org: navOrg(state, ownProps.params.organization) || {}
   }
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 import { actionTypes as petitionActionTypes } from '../actions/petitionActions.js'
 import { actionTypes as sessionActionTypes } from '../actions/sessionActions.js'
-import navStore from './nav'
+import nav from './nav'
 // Function fetchPetitionRequest(petitionSlug) {
 //     Return {
 //         Type: FETCH_PETTION_REQUEST,
@@ -232,7 +232,7 @@ function userReducer(state = initialUserState, action) {
 }
 
 const rootReducer = combineReducers({
-  navStore,
+  nav,
   petitionStore: petitionReducer,
   petitionSearchStore: petitionSearchReducer,
   userStore: userReducer

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,5 +1,5 @@
 
-export const navOrg = (state, org) => state.nav.orgs && state.nav.orgs[org]
+export const navOrg = (state, org) => state.nav && state.nav.orgs && state.nav.orgs[org]
 export const cobrand = (state) => state.nav.partnerCobrand
 export const orgCobrand = (state, org) =>
   (org ? navOrg(state, org) : cobrand(state))

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,0 +1,6 @@
+
+export const navOrg = (state, org) => state.navStore.orgs && state.navStore.orgs[org]
+export const cobrand = (state) => state.navStore.partnerCobrand
+export const orgCobrand = (state, org) =>
+  (org ? navOrg(state, org) : cobrand(state))
+

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,6 +1,6 @@
 
-export const navOrg = (state, org) => state.navStore.orgs && state.navStore.orgs[org]
-export const cobrand = (state) => state.navStore.partnerCobrand
+export const navOrg = (state, org) => state.nav.orgs && state.nav.orgs[org]
+export const cobrand = (state) => state.nav.partnerCobrand
 export const orgCobrand = (state, org) =>
   (org ? navOrg(state, org) : cobrand(state))
 

--- a/test/pages/home.js
+++ b/test/pages/home.js
@@ -13,8 +13,8 @@ import TopPetitions from '../../src/components/top-petitions'
 
 
 describe('<Home />', () => {
-  const baseStore = createMockStore({ navStore: {}, petitionStore: {} })
-  const orgStore = createMockStore({ navStore: { orgs: {
+  const baseStore = createMockStore({ nav: {}, petitionStore: {} })
+  const orgStore = createMockStore({ nav: { orgs: {
     mop: {
       organization: 'M.O.P.',
       description: 'MOP stands for Mash Out Posse or MoveOn Petitions or ....',


### PR DESCRIPTION
This introduces a new concept in your redux implementation called "selectors"

Selectors in general allow you to write simpler `mapStateToProps` methods, they generally take the form of `(state, ...otherParams) => state.someKey`

This also allows you (as you can see in the second commit) to rename the location of storage in the redux state, and so long as you only ever use selectors to query the state, will ensure that we can change how the information is stored, and optimize the selectors.

In order to properly use this abstraction layer, we should never read properties directly from redux state, instead use `someSelector(state)` to get at the information we need, writing a selector if need be.