### PR TITLE
Switch tests for Home to be shallow and not use redux

### DIFF
--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -3,6 +3,7 @@ import { navOrg } from '../selectors/nav'
 
 import Config from '../config.js'
 
+
 export const actionTypes = {
   FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
   FETCH_ORG_SUCCESS: 'FETCH_ORG_SUCCESS',

--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -1,6 +1,8 @@
 import 'whatwg-fetch'
+import { navOrg } from '../selectors/nav'
 
 import Config from '../config.js'
+
 
 export const actionTypes = {
   FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
@@ -8,31 +10,30 @@ export const actionTypes = {
   FETCH_ORG_FAILURE: 'FETCH_ORG_FAILURE'
 }
 
-export function loadOrganization(orgSlug, forceReload) {
-  const urlKey = `organizations/${orgSlug}`
+export function loadOrganization(slug, forceReload) {
+  const urlKey = `organizations/${slug}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
     return (dispatch) => {
       dispatch({
         type: actionTypes.FETCH_ORG_SUCCESS,
         org: window.preloadObjects[urlKey],
-        slug: orgSlug
+        slug
       })
     }
   }
   return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_ORG_REQUEST,
-      slug: orgSlug
+      slug
     })
-    const { navStore } = getState()
-    if (!forceReload
-        && navStore
-        && navStore.orgs
-        && navStore.orgs[orgSlug]) {
+    const state = getState()
+    const org = navOrg(state, slug)
+
+    if (!forceReload && org) {
       return dispatch({
         type: actionTypes.FETCH_ORG_SUCCESS,
-        org: navStore.orgs[orgSlug],
-        slug: orgSlug
+        org,
+        slug
       })
     }
     return fetch(`${Config.API_URI}/api/v1/${urlKey}.json`)
@@ -41,14 +42,14 @@ export function loadOrganization(orgSlug, forceReload) {
           dispatch({
             type: actionTypes.FETCH_ORG_SUCCESS,
             org: json,
-            slug: json.name || orgSlug
+            slug: json.name || slug
           })
         }),
         (err) => {
           dispatch({
             type: actionTypes.FETCH_ORG_FAILURE,
             error: err,
-            slug: orgSlug
+            slug
           })
         }
       )

--- a/src/actions/navActions.js
+++ b/src/actions/navActions.js
@@ -3,7 +3,6 @@ import { navOrg } from '../selectors/nav'
 
 import Config from '../config.js'
 
-
 export const actionTypes = {
   FETCH_ORG_REQUEST: 'FETCH_ORG_REQUEST',
   FETCH_ORG_SUCCESS: 'FETCH_ORG_SUCCESS',

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { orgCobrand } from '../selectors/nav'
 
 import NavLink from './nav-link'
 
-const Nav = ({ user, nav, organization }) => {
-  const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
-
+const Nav = ({ user, cobrand }) => {
   const userLinks = (
     <div className='pull-right bump-top-1 span-7 top-menu'>
       <ul className='nav collapse nav-collapse'>
@@ -30,17 +29,21 @@ const Nav = ({ user, nav, organization }) => {
   )
 
   const userDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</a>
+    <a
+      className='icon-link-narrow icon-managepetitions'
+      href='https://petitions.moveon.org/dashboard.html?source=topnav'
+    > {`${user.given_name}’s`} Dashboard</a>
   )
 
   const guestDashboardLink = (
     <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'>Manage Petitions</a>
   )
 
-  const partnerLogoLinks = (
-    (cobrand)
-      ? (<a href={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></a>
-        ) : null)
+  const partnerLogoLinks = cobrand && (
+    <a href={cobrand.browser_url}>
+      <img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} />
+    </a>
+  )
 
   return (
     <div>
@@ -90,14 +93,14 @@ const Nav = ({ user, nav, organization }) => {
 
 Nav.propTypes = {
   user: PropTypes.object,
-  nav: PropTypes.object,
+  cobrand: PropTypes.object,
   organization: PropTypes.string
 }
 
-function mapStateToProps(store) {
+function mapStateToProps(state, ownProps) {
   return {
-    user: store.userStore,
-    nav: store.navStore
+    user: state.userStore,
+    cobrand: orgCobrand(state, ownProps.organization)
   }
 }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -2,17 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { navOrg } from '../selectors/nav'
 import { Config } from '../config.js'
 import BillBoard from '../components/billboard'
 import SearchBar from '../components/searchbar'
 import RecentVictoryList from '../components/recentvictory.js'
 import TopPetitions from '../components/top-petitions'
 
-const Home = ({ params, nav }) => {
+const Home = ({ params, org }) => {
   const { organization } = params
   const isOrganization = Boolean(organization && organization !== 'pac')
   const isPac = (organization === 'pac' || (!isOrganization && Config.ENTITY === 'pac'))
-  const orgData = (nav && nav.orgs && nav.orgs[organization]) || {}
   return (
     <div className='moveon-petitions container background-moveon-white bump-top-1'>
       {isOrganization ? null : <BillBoard />}
@@ -21,8 +21,8 @@ const Home = ({ params, nav }) => {
       {isOrganization
        ? (
         <div className='organization-header'>
-          <h2>{orgData.organization}</h2>
-          {orgData.description || `${orgData.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
+          <h2>{org.organization}</h2>
+          {org.description || `${org.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
           <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>
         </div>
        ) : null
@@ -42,13 +42,13 @@ const Home = ({ params, nav }) => {
 }
 
 Home.propTypes = {
-  nav: PropTypes.object,
+  org: PropTypes.object,
   params: PropTypes.object
 }
 
-function mapStateToProps(store) {
+function mapStateToProps(state, ownProps) {
   return {
-    nav: store.navStore
+    org: navOrg(state, ownProps.params.organization)
   }
 }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -9,24 +9,33 @@ import SearchBar from '../components/searchbar'
 import RecentVictoryList from '../components/recentvictory.js'
 import TopPetitions from '../components/top-petitions'
 
-const Home = ({ params, org }) => {
-  const { organization } = params
+const Home = ({ params: { organization }, org }) => {
   const isOrganization = Boolean(organization && organization !== 'pac')
+  const notOrganization = !isOrganization
   const isPac = (organization === 'pac' || (!isOrganization && Config.ENTITY === 'pac'))
+
+  // Pull the properties from the organization object
+  // use a default description if none is defined.
+  const {
+    // orgName = org.organization || params.organization
+    organization: orgName = organization,
+    description = `${orgName} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`
+  } = org
+
   return (
     <div className='moveon-petitions container background-moveon-white bump-top-1'>
-      {isOrganization ? null : <BillBoard />}
+      {notOrganization && <BillBoard />}
       <SearchBar />
 
-      {isOrganization
-       ? (
+      {isOrganization && (
         <div className='organization-header'>
-          <h2>{org.organization}</h2>
-          {org.description || `${org.organization} is a MoveOn MegaPartner, an invite-only program that lets a partner organization&#39;s members and activists set up their own MoveOn petitions in partnership with the original organization.`}
-          <p className='pull-right'><a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a></p>
+          <h2>{orgName}</h2>
+          {description}
+          <p className='pull-right'>
+            <a href='create_start.html' className='button background-moveon-bright-red'>Create a petition</a>
+          </p>
         </div>
-       ) : null
-      }
+       )}
 
       <div className='row front-content'>
         <TopPetitions
@@ -35,7 +44,7 @@ const Home = ({ params, org }) => {
           fullWidth={isOrganization}
           source='homepage'
         />
-        {isOrganization ? null : <RecentVictoryList />}
+        {notOrganization && <RecentVictoryList />}
       </div>
     </div>
   )

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -46,9 +46,13 @@ Home.propTypes = {
   params: PropTypes.object
 }
 
+Home.defaultProps = {
+  params: {}
+}
+
 function mapStateToProps(state, ownProps) {
   return {
-    org: navOrg(state, ownProps.params.organization)
+    org: navOrg(state, ownProps.params.organization) || {}
   }
 }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -47,7 +47,8 @@ Home.propTypes = {
 }
 
 Home.defaultProps = {
-  params: {}
+  params: {},
+  org: {}
 }
 
 function mapStateToProps(state, ownProps) {
@@ -57,3 +58,5 @@ function mapStateToProps(state, ownProps) {
 }
 
 export default connect(mapStateToProps)(Home)
+
+export const WrappedComponent = Home

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 import { actionTypes as petitionActionTypes } from '../actions/petitionActions.js'
 import { actionTypes as sessionActionTypes } from '../actions/sessionActions.js'
-import navStore from './nav'
+import nav from './nav'
 // Function fetchPetitionRequest(petitionSlug) {
 //     Return {
 //         Type: FETCH_PETTION_REQUEST,
@@ -232,7 +232,7 @@ function userReducer(state = initialUserState, action) {
 }
 
 const rootReducer = combineReducers({
-  navStore,
+  nav,
   petitionStore: petitionReducer,
   petitionSearchStore: petitionSearchReducer,
   userStore: userReducer

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,5 +1,5 @@
 
-export const navOrg = (state, org) => state.nav.orgs && state.nav.orgs[org]
+export const navOrg = (state, org) => state.nav && state.nav.orgs && state.nav.orgs[org]
 export const cobrand = (state) => state.nav.partnerCobrand
 export const orgCobrand = (state, org) =>
   (org ? navOrg(state, org) : cobrand(state))

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,0 +1,6 @@
+
+export const navOrg = (state, org) => state.navStore.orgs && state.navStore.orgs[org]
+export const cobrand = (state) => state.navStore.partnerCobrand
+export const orgCobrand = (state, org) =>
+  (org ? navOrg(state, org) : cobrand(state))
+

--- a/src/selectors/nav.js
+++ b/src/selectors/nav.js
@@ -1,6 +1,6 @@
 
-export const navOrg = (state, org) => state.navStore.orgs && state.navStore.orgs[org]
-export const cobrand = (state) => state.navStore.partnerCobrand
+export const navOrg = (state, org) => state.nav.orgs && state.nav.orgs[org]
+export const cobrand = (state) => state.nav.partnerCobrand
 export const orgCobrand = (state, org) =>
   (org ? navOrg(state, org) : cobrand(state))
 

--- a/test/pages/home.js
+++ b/test/pages/home.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import { Provider } from 'react-redux'
 import { expect } from 'chai'
 
-import { mount } from 'enzyme'
-import { createMockStore } from 'redux-test-utils'
+import { shallow } from 'enzyme'
 
-import Home from '../../src/pages/home'
+import { WrappedComponent as Home } from '../../src/pages/home'
 import BillBoard from '../../src/components/billboard'
 import SearchBar from '../../src/components/searchbar'
 import RecentVictoryList from '../../src/components/recentvictory'
@@ -13,35 +11,29 @@ import TopPetitions from '../../src/components/top-petitions'
 
 
 describe('<Home />', () => {
-  const baseStore = createMockStore({ nav: {}, petitionStore: {} })
-  const orgStore = createMockStore({ nav: { orgs: {
-    mop: {
-      organization: 'M.O.P.',
-      description: 'MOP stands for Mash Out Posse or MoveOn Petitions or ....',
-      logo_image_url: 'https://example.com/mopimage.jpg'
-    }
-  } }, petitionStore: {} })
+  const mockOrg = {
+    organization: 'M.O.P.',
+    description: 'MOP stands for Mash Out Posse or MoveOn Petitions or ....',
+    logo_image_url: 'https://example.com/mopimage.jpg'
+  }
+
   it('renders a billboard', () => {
-    const myComponent = <Home params={{}} />
-    const context = mount(<Provider store={baseStore} children={myComponent} />)
+    const context = shallow(<Home />)
     expect(context.find(BillBoard)).to.have.length(1)
   })
 
   it('renders a searchbar', () => {
-    const myComponent = <Home params={{}} />
-    const context = mount(<Provider store={baseStore} children={myComponent} />)
+    const context = shallow(<Home />)
     expect(context.find(SearchBar)).to.have.length(1)
   })
 
   it('renders a recent victory list inside .front-content', () => {
-    const myComponent = <Home params={{}} />
-    const context = mount(<Provider store={baseStore} children={myComponent} />)
+    const context = shallow(<Home />)
     expect(context.find('.front-content').find(RecentVictoryList)).to.have.length(1)
   })
 
   it('renders org content', () => {
-    const myComponent = <Home params={{ organization: 'mop' }} />
-    const context = mount(<Provider store={orgStore} children={myComponent} />)
+    const context = shallow(<Home org={mockOrg} params={{ organization: 'mop' }} />)
     const orgHeader = context.find('.organization-header')
     expect(orgHeader).to.have.length(1)
     expect(orgHeader.find('h2').text()).to.be.equal('M.O.P.')

--- a/test/pages/home.js
+++ b/test/pages/home.js
@@ -13,8 +13,8 @@ import TopPetitions from '../../src/components/top-petitions'
 
 
 describe('<Home />', () => {
-  const baseStore = createMockStore({ navStore: {}, petitionStore: {} })
-  const orgStore = createMockStore({ navStore: { orgs: {
+  const baseStore = createMockStore({ nav: {}, petitionStore: {} })
+  const orgStore = createMockStore({ nav: { orgs: {
     mop: {
       organization: 'M.O.P.',
       description: 'MOP stands for Mash Out Posse or MoveOn Petitions or ....',

--- a/test/pages/home.js
+++ b/test/pages/home.js
@@ -22,6 +22,16 @@ describe('<Home />', () => {
     expect(context.find(BillBoard)).to.have.length(1)
   })
 
+  it('does not render billboard when organization', () => {
+    const context = shallow(<Home params={{ organization: 'mop' }} />)
+    expect(context.find(BillBoard)).to.have.length(0)
+  })
+
+  it('renders billboard for "pac" organization', () => {
+    const context = shallow(<Home params={{ organization: 'pac' }} />)
+    expect(context.find(BillBoard)).to.have.length(1)
+  })
+
   it('renders a searchbar', () => {
     const context = shallow(<Home />)
     expect(context.find(SearchBar)).to.have.length(1)
@@ -30,6 +40,13 @@ describe('<Home />', () => {
   it('renders a recent victory list inside .front-content', () => {
     const context = shallow(<Home />)
     expect(context.find('.front-content').find(RecentVictoryList)).to.have.length(1)
+  })
+
+  it('does not render org header if no organization, or organization pac', () => {
+    const context = shallow(<Home />)
+    const pacContext = shallow(<Home params={{ organization: 'pac' }} />)
+    expect(context.find('.organization-header')).to.have.length(0)
+    expect(pacContext.find('.organization-header'), 'pac').to.have.length(0)
   })
 
   it('renders org content', () => {


### PR DESCRIPTION
**This PR requires #159 to land first, but wanted to get this submitted sooner rather than later.**

**Pay the most attention to the last commit 7a0afa7 during review.**

This switches the tests for `<Home />` to shallow test only the inner component. the connect / redux bits don't need to be tested as deeply, but if you wanted, you could also just test the `mapStateToProps` function.

By exporting the `WrappedComponent` without the connect wrapper, we can completely avoid mounting deeply, or with redux states at all and worry about what we want the component to present when given data.

After this change, these 4 tests that I swapped over are already saving ~75ms each just switching to shallow instead of mount, and avoiding setting up stores.

shallow / reduxless tests
```
  4 passing (165ms)
  4 passing (160ms)
  4 passing (142ms)
  4 passing (144ms)
  4 passing (139ms)
  4 passing (146ms)
  4 passing (140ms)
  4 passing (141ms)
  4 passing (146ms)
  4 passing (140ms)
```

vs mount/provider/store tests

```
  4 passing (508ms)
  4 passing (437ms)
  4 passing (352ms)
  4 passing (502ms)
  4 passing (354ms)
  4 passing (356ms)
  4 passing (351ms)
  4 passing (361ms)
  4 passing (363ms)
  4 passing (343ms)
```

If y'all wanna test the times on your own machines, here's the command I used to generate the output:
```bash
for i in $(seq 1 10); do mocha --compilers js:babel-core/register --require jsdom-global/register --require isomorphic-fetch test/pages/home.js  | grep passing ; done
```