### PR TITLE
Thanks page finishings

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -156,7 +156,7 @@ export function loadTopPetitions(pac, megapartner, forceReload) {
   }
 }
 
-export const registerSignatureAndThanks = (petition) => () => {
+export const registerSignatureAndThanks = (petition, signature) => () => {
   // 1. track petition success
   if (window.fbq) {
     window.fbq('track', 'Lead') // facebook lead
@@ -169,14 +169,16 @@ export const registerSignatureAndThanks = (petition) => () => {
   let thanksUrl = 'thanks.html'
   if (petition.thanks_url) {
     if (/^https?:\/\//.test(petition.thanks_url)) {
-      document.location = petition.thanks_url // TODO: maybe add some query params
+      document.location = petition.thanks_url // FUTURE: maybe add some query params
       return
     }
     thanksUrl = petition.thanks_url
   }
+  const { referrer_data: { source } = {} } = signature
+  const fromSource = (source ? `&from_source=${encodeURIComponent(source)}` : '')
   appLocation.push(`${thanksUrl}?petition_id=${
     petition.petition_id
-  }&name=${petition.name}`)
+  }&name=${petition.name}${fromSource}`)
 }
 
 export function signPetition(petitionSignature, petition, options) {
@@ -206,7 +208,7 @@ export function signPetition(petitionSignature, petition, options) {
         }
         const dispatchResult = dispatch(dispatchData)
         if (options && options.redirectOnSuccess) {
-          registerSignatureAndThanks(dispatchResult.petition)(dispatch)
+          registerSignatureAndThanks(dispatchResult.petition, dispatchResult.signature)(dispatch)
         }
       }
       if (data && typeof data.json === 'function') {

--- a/src/components/billboard.js
+++ b/src/components/billboard.js
@@ -7,7 +7,7 @@ const billboardButton = {
   fontSize: '99%'
 }
 
-// TODO: make start a petition a <Link>
+// TODO: make start a petition a <Link> when we have implemented petition creation
 
 const BillBoard = () => (
   <div className='container'>

--- a/src/pages/thanks.js
+++ b/src/pages/thanks.js
@@ -15,10 +15,11 @@ class ThanksPage extends React.Component {
 
     const { dispatch, petition } = this.props
     if (!petition) {
-      if (this.props.location.query.name) {
-        dispatch(petitionActions.loadPetition(this.props.location.query.name))
-      } else if (this.props.location.query.petition_id) {
-        dispatch(petitionActions.loadPetition(this.props.location.query.petition_id))
+      const query = this.props.location.query
+      if (query.name) {
+        dispatch(petitionActions.loadPetition(query.name))
+      } else if (query.petition_id) {
+        dispatch(petitionActions.loadPetition(query.petition_id))
       }
     }
   }
@@ -31,6 +32,7 @@ class ThanksPage extends React.Component {
             petition={this.props.petition}
             user={this.props.user}
             signatureMessage={this.props.signatureMessage}
+            fromSource={this.props.location.query.from_source}
           />
           : ''
         )}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -215,7 +215,6 @@ function userReducer(state = initialUserState, action) {
         if (action.signature.person.email_addresses
             && action.signature.person.email_addresses.length) {
           newData.email = action.signature.person.email_addresses[0]
-          // TODO: possibly generate an md5hash here
         }
         if (action.signature.person.postal_addresses
             && action.signature.person.postal_addresses.length) {


### PR DESCRIPTION
This implements two things that were marked TODO:
* passing the  ?from_source= parameter from the sign page to the thanks page and having that change the `pre` variable
* doing some length logic around really long petition statements for the mail message.

This is on top of PR: https://github.com/MoveOnOrg/mop-frontend/pull/165
so we should merge that first, and then I'll rebase this.