### PR TITLE
convert all http:// => https://

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -11,33 +11,33 @@ const Footer = () => (
         </div>
         <div className='row'>
           <div className='span4'>
-            <a className='icon-start icon-link-narrow' href='http://petitions.moveon.org/create_start.html?source=bnav'>Start a Petition</a>
-            <a className='icon-link-narrow icon-managepetitions' href='http://petitions.moveon.org/dashboard.html'>Dashboard</a>
+            <a className='icon-start icon-link-narrow' href='https://petitions.moveon.org/create_start.html?source=bnav'>Start a Petition</a>
+            <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html'>Dashboard</a>
             <ul className='nav'>
               <li><a className='lh-14 navlink' href='/login/do_logout.html?redirect=/index.html'>Logout</a></li>
               <li><a href='https://petitions.moveon.org/organizations.html'>Organizations</a></li>
-              <li><a href='http://front.moveon.org/category/victories/'>Victories</a></li>
+              <li><a href='https://front.moveon.org/category/victories/'>Victories</a></li>
               <li><a href='https://civic.moveon.org/donatec4/creditcard.html?cpn_id=511'>Donate</a></li>
-              <li><a href='http://pol.moveon.org/feedback/press/'>Press</a></li>
+              <li><a href='https://act.moveon.org/survey/press'>Press</a></li>
               <li><a href='https://petitions.moveon.org/feedback.html'>Contact</a></li>
-              <li><a href='http://front.moveon.org/blog/'>Blog</a></li>
+              <li><a href='https://front.moveon.org/blog/'>Blog</a></li>
               <li><a href='https://petitions.moveon.org/login/register.html'>Sign Up</a></li>
               <li><a href='https://petitions.moveon.org/privacy.html'>Privacy Policy</a></li>
               <li><a href='https://petitions.moveon.org/terms.html'>Terms of Use</a></li>
-              <li><a href='http://front.moveon.org/careers'>Careers</a></li>
+              <li><a href='https://front.moveon.org/careers'>Careers</a></li>
             </ul>
           </div>
         </div>
       </div>
       <div className='lh-20 span8 disclaimer bump-top-1'>
         <p>A joint website of MoveOn.org Civic Action and MoveOn.org Political Action.</p>
-        <p><a href='http://civic.moveon.org/'>MoveOn.org Civic Action</a> is a 501(c)(4) organization which primarily focuses on nonpartisan education and advocacy on important national issues. MoveOn.org Political Action is a federal political committee which primarily helps members elect candidates who reflect our values through a variety of activities aimed at influencing the outcome of the next election. MoveOn.org Political Action and MoveOn.org Civic Action are separate organizations.</p>
+        <p><a href='https://civic.moveon.org/'>MoveOn.org Civic Action</a> is a 501(c)(4) organization which primarily focuses on nonpartisan education and advocacy on important national issues. MoveOn.org Political Action is a federal political committee which primarily helps members elect candidates who reflect our values through a variety of activities aimed at influencing the outcome of the next election. MoveOn.org Political Action and MoveOn.org Civic Action are separate organizations.</p>
       </div>
     </div>
     <ul className='unstyled'>
-      <li><a href='http://www.facebook.com/moveon' className='icon-fb black-navlink'>Follow us on Facebook</a></li>
-      <li><a href='http://www.twitter.com/moveon' className='icon-twitter black-navlink'>Follow us on Twitter</a></li>
-      <li><a href='http://civic.moveon.org/keepmeposted/' className='icon-join black-navlink'>Newsletter Signup</a></li>
+      <li><a href='https://www.facebook.com/moveon' className='icon-fb black-navlink'>Follow us on Facebook</a></li>
+      <li><a href='https://www.twitter.com/moveon' className='icon-twitter black-navlink'>Follow us on Twitter</a></li>
+      <li><a href='https://civic.moveon.org/keepmeposted/' className='icon-join black-navlink'>Newsletter Signup</a></li>
     </ul>
   </div>
 )

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -30,11 +30,11 @@ const Nav = ({ user, nav, organization }) => {
   )
 
   const userDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='http://petitions.moveon.org/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</a>
+    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</a>
   )
 
   const guestDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='http://petitions.moveon.org/dashboard.html?source=topnav'>Manage Petitions</a>
+    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'>Manage Petitions</a>
   )
 
   const partnerLogoLinks = (
@@ -60,13 +60,13 @@ const Nav = ({ user, nav, organization }) => {
             <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
               {partnerLogoLinks}
             </div>
-            <a className='icon-link-narrow icon-start' href='http://petitions.moveon.org/create_start.html?source=topnav'>Start a petition</a>
+            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav'>Start a petition</a>
             {user.given_name ? userDashboardLink : guestDashboardLink}
           </div>
 
           <div className='pull-left top-icons visible-phone'>
-            <a className='icon-link-narrow icon-start' href='http://petitions.moveon.org/create_start.html?source=topnav-mobile'></a>
-            <a className='icon-link-narrow icon-managepetitions' href='http://petitions.moveon.org/dashboard.html'></a>
+            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav-mobile'></a>
+            <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html'></a>
           </div>
 
           <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>

--- a/src/components/recentvictory.js
+++ b/src/components/recentvictory.js
@@ -7,71 +7,71 @@ const RecentVictoryList = () => (
   <div id='current-stories' className='span6 widget clearfix pull-left'>
     <div className='widget-top clearfix'>
       <h3>Recent Victories</h3>
-      <a className='more-small' href='http://front.moveon.org/category/victories/'>+more</a>
+      <a className='more-small' href='https://front.moveon.org/category/victories/'>+more</a>
     </div>
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/category/victories/#.U4z0eK1dUuo'>
-        <img src='http://front.moveon.org/wp-content/uploads/2014/06/CCMC.So_.Cal_.Summit.2014.04.06.1.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Cal_Summit' />
+      <a href='https://front.moveon.org/category/victories/#.U4z0eK1dUuo'>
+        <img src='https://front.moveon.org/wp-content/uploads/2014/06/CCMC.So_.Cal_.Summit.2014.04.06.1.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Cal_Summit' />
         <h4>VICTORY: Gov. Brown Signs Dark Money Disclosure Bill into Law</h4>
       </a>
       <p className='blurb'>
         In the wake of the large sums of out-of-state anonymous donations that flooded into California during the 2012 election, the Legislature took up SB27, which would require political nonprofits to identify their donors in California elections. So Trent Lange of the California Clean Money Campaign, along with allies including California Common Cause, Credo Action, Courage Campaign, MoveOn.org, and others, launched a campaign to get the bill passed.
-        <a href='http://front.moveon.org/category/victories/#.U4z0eK1dUuo'>(Read More)</a>
+        <a href='https://front.moveon.org/category/victories/#.U4z0eK1dUuo'>(Read More)</a>
       </p>
     </article>
 
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/victory-hawaii-increases-the-minimum-wage/#.U4z2KK1dUuo'>
-        <img src='http://front.moveon.org/wp-content/uploads/2014/06/HI.needs_.a.raise_-620x394.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='HI_minwage' />
+      <a href='https://front.moveon.org/victory-hawaii-increases-the-minimum-wage/#.U4z2KK1dUuo'>
+        <img src='https://front.moveon.org/wp-content/uploads/2014/06/HI.needs_.a.raise_-620x394.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='HI_minwage' />
         <h4>VICTORY: Hawaii Increases the Minimum Wage!</h4>
       </a>
       <p className='blurb'>
         When the Hawaii Legislature took up an important bill to raise the minimum wage, Drew Astolfi of the organization Faith Action for Community Equity, along with allies and the Hawaii MoveOn Council, launched a campaign to raise wages for workers in the state.
-        <a href='http://front.moveon.org/victory-hawaii-increases-the-minimum-wage/#.U4z2KK1dUuo'>(Read More)</a>
+        <a href='https://front.moveon.org/victory-hawaii-increases-the-minimum-wage/#.U4z2KK1dUuo'>(Read More)</a>
       </p>
     </article>
 
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/victory-ny-times-works-to-inform-readers-on-budget/?rc=petitionshp'>
-        <img src='http://moveon.wpengine.netdna-cdn.com/wp-content/uploads/2013/11/NYTimes.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' />
+      <a href='https://front.moveon.org/victory-ny-times-works-to-inform-readers-on-budget/?rc=petitionshp'>
+        <img src='https://front.moveon.org/wp-content/uploads/2013/11/NYTimes.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' />
         <h4>VICTORY: New York Times Works to Inform Readers on Budget</h4>
       </a>
       <p className='blurb'>
         The New York Times&#39; tendency to report on budget numbers without contextualizing them was a problem - especially in light of the recent federal budget crisis. MoveOn member (and former staffer) Daniel Mintz and Robert Naiman of Just Foreign Policy started MoveOn Petitions to Times Public Editor Margaret Sullivan, asking her to institute a policy of always reporting budget numbers with percentages or comparisons.
-        <a href='http://front.moveon.org/victory-ny-times-works-to-inform-readers-on-budget/?rc=petitionshp'>(Read More)</a>
+        <a href='https://front.moveon.org/victory-ny-times-works-to-inform-readers-on-budget/?rc=petitionshp'>(Read More)</a>
       </p>
     </article>
 
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/victory-governor-corbett-releases-education-dollars-to-philadelphia-schools/?rc=petitionshp'>
-        <img src='http://moveon.wpengine.netdna-cdn.com/wp-content/uploads/2013/11/Philly.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' height='200' />
+      <a href='https://front.moveon.org/victory-governor-corbett-releases-education-dollars-to-philadelphia-schools/?rc=petitionshp'>
+        <img src='https://front.moveon.org/wp-content/uploads/2013/11/Philly.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' height='200' />
         <h4>VICTORY: Governor Corbett Releases Education Dollars To Philadelphia Schools</h4>
       </a>
       <p className='blurb'>
         In October 2013, a student at one Philadelphia school suffered from an asthma attack that led to her death. If there had been a school nurse on campus that day, she might still be alive. This tragedy motivated Philadelphia parent Jesse Bacon to start a MoveOn Petition to Governor Tom Corbett, asking him to stop withholding $45 million of funding from Philadelphia schools.
-        <a href='http://front.moveon.org/victory-governor-corbett-releases-education-dollars-to-philadelphia-schools/?rc=petitionshp'>(Read More)</a>
+        <a href='https://front.moveon.org/victory-governor-corbett-releases-education-dollars-to-philadelphia-schools/?rc=petitionshp'>(Read More)</a>
       </p>
     </article>
 
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/51832/?rc=petitionshp'>
-        <img src='http://moveon.wpengine.netdna-cdn.com/wp-content/uploads/2013/09/Los_Angeles_Times_interior_with_globe.1.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' />
+      <a href='https://front.moveon.org/51832/?rc=petitionshp'>
+        <img src='https://front.moveon.org/wp-content/uploads/2013/09/Los_Angeles_Times_interior_with_globe.1.jpg' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='Tribune' />
         <h4>VICTORY: Tribune Papers Spared From Koch Empire</h4>
       </a>
       <p className='blurb'>
         When the Tribune Company went up for sale, it was widely reported that the Koch brothers were interested in acquiring its newspapers - including the Los Angeles Times and the Chicago Tribune. The billionaire Kochs and their tea party politics presented a clear threat to independent journalism, so several organizations, including Forecast the Facts, Courage Campaign, and Working Families started MoveOn Petitions asking Tribune Company CEO Peter Liguori not to sell to the Koch brothers.
-        <a href='http://front.moveon.org/51832/?rc=petitionshp'>(Read More)</a>
+        <a href='https://front.moveon.org/51832/?rc=petitionshp'>(Read More)</a>
       </p>
     </article>
 
     <article className='blurb-block'>
-      <a href='http://front.moveon.org/victory-defend-the-vote-campaign-secures-support-for-voting-rights-amendment-act/#.U4z4Ia1dUup'>
-        <img src='http://front.moveon.org/wp-content/uploads/2014/02/DefendVote-V10.png' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='voting_rights' />
+      <a href='https://front.moveon.org/victory-defend-the-vote-campaign-secures-support-for-voting-rights-amendment-act/#.U4z4Ia1dUup'>
+        <img src='https://front.moveon.org/wp-content/uploads/2014/02/DefendVote-V10.png' style={imgArticle} className='attachment-featured_thumb wp-post-image' alt='voting_rights' />
         <h4>VICTORY: Defend the Vote Campaign Secures Support for Voting Rights Amendment Act</h4>
       </a>
       <p className='blurb'>
         All around the country, voting rights are under attack—but MoveOn members are fighting back by running hundreds of campaigns to defend these critical rights as a part of our Defend the Vote campaign.
-        <a href='http://front.moveon.org/victory-defend-the-vote-campaign-secures-support-for-voting-rights-amendment-act/#.U4z4Ia1dUup'>(Read More)</a>
+        <a href='https://front.moveon.org/victory-defend-the-vote-campaign-secures-support-for-voting-rights-amendment-act/#.U4z4Ia1dUup'>(Read More)</a>
       </p>
     </article>
   </div>

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -383,7 +383,7 @@ class SignatureAddForm extends React.Component {
 
            {(this.props.showOptinWarning) ? (
              <p className='disclaimer bump-top-1'>
-               <b>Note:</b> This petition is a project of {creator.organization} and MoveOn.org. By signing, you agree to receive email messages from <span id='organization_receive'>{creator.organization}, </span>MoveOn Political Action, and MoveOn Civic Action. You may unsubscribe at any time. [<a href='http://petitions.moveon.org/privacy.html'>privacy policy</a>]
+               <b>Note:</b> This petition is a project of {creator.organization} and MoveOn.org. By signing, you agree to receive email messages from <span id='organization_receive'>{creator.organization}, </span>MoveOn Political Action, and MoveOn Civic Action. You may unsubscribe at any time. [<a href='https://petitions.moveon.org/privacy.html'>privacy policy</a>]
              </p>)
             : (
              <p className='disclaimer bump-top-1'>

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -75,7 +75,7 @@ class Thanks extends React.Component {
 
   shareTwitter() {
     const encodedValue = encodeURIComponent(this.tweetTextArea.value)
-    const url = `http://twitter.com/intent/tweet?text=${encodedValue}`
+    const url = `https://twitter.com/intent/tweet?text=${encodedValue}`
     window.open(url)
     this.recordShare('twitter', `${this.state.pre}.tw`)
     this.setState({ sharedSocially: true })


### PR DESCRIPTION
Change all hard-coded links to https for security and it's 2018.

Most of these are straight changes.  There are two 'special' changes:
1. The press link in our footer now 404s, so I updated it
2. http://moveon.wpengine.netdna-cdn.com/wp-content/uploads/2013/11/NYTimes.jpg and other links from that domain don't support https.  However all the same content is available from the host: `https://front.moveon.org`, e.g. https://front.moveon.org/wp-content/uploads/2013/11/NYTimes.jpg