### PR TITLE
fix hide/show optin bug and get a special link for the link share

### DIFF
--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -438,13 +438,14 @@ function mapStateToProps(store, ownProps) {
                                                     || (creator.custom_fields && creator.custom_fields.may_optin)))
 
   newProps.hiddenOptin = !!(!user.signonId && ((creator.source && ((newProps.fromCreator && !query.mailing_id)
-                                                                   || query.mega_partner && !newProps.fromMailing))
+                                                                   || !newProps.fromMailing))
                                                || (!creator.source
                                                    && creator.custom_fields && creator.custom_fields.may_optin
                                                    && newProps.fromCreator
                                                    && !query.mailing_id)))
 
   newProps.showOptinCheckbox = !!(!user.signonId && newProps.showOptinWarning && !newProps.hiddenOptin)
+
   return newProps
 }
 

--- a/src/components/thanks.js
+++ b/src/components/thanks.js
@@ -118,12 +118,12 @@ Thanks!
 
   render() {
     const { petition, signatureMessage, user } = this.props
-    const link = petition._links.url
     const shortLinkArgs = [
       petition.petition_id,
       user && user.signonId,
       signatureMessage && signatureMessage.messageMd5]
     const twitterShareLink = petitionShortCode((this.isCreator ? 'c' : 't'), ...shortLinkArgs)
+    const rawShareLink = petitionShortCode((this.isCreator ? 'k' : 'l'), ...shortLinkArgs)
     const shareOpts = (petition.share_options && petition.share_options[0]) || {}
     // Convert description to text
     const textDescription = document.createElement('div')
@@ -141,7 +141,7 @@ Thanks!
                                                    this.isCreator,
                                                    shareOpts,
                                                    petition.target,
-                                                   `${link}?source=${this.state.pre}.em.__TYPE__&${this.trackingParams}`
+                                                   `${petition._links.url}?source=${this.state.pre}.em.__TYPE__&${this.trackingParams}`
                                                    )
     const copyPasteMessage = `Subject: ${petition.summary}\n\n${mailToMessage.replace('__TYPE__', 'cp')}`
     const mailtoMessage = `mailto:?subject=${encodeURIComponent(petition.summary)}&body=${encodeURIComponent(mailToMessage.replace('__TYPE__', 'mt'))}`
@@ -189,7 +189,7 @@ Thanks!
             ref={(input) => { this.linkTextarea = input }}
             onClick={this.shareLink}
             id='link_text'
-            defaultValue={link}
+            defaultValue={rawShareLink}
             readOnly
           ></textarea>
         </div>

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -135,7 +135,8 @@ describe('<SignatureAddForm />', () => {
     it('optin checkbox or hidden optin: hide profiles', () => {
       const hideProfiles = [ // Should have hidden optin
         { petition: 'megapartner_mayoptin', query: { source: 'c.123' } },
-        { petition: 'megapartner_mayoptin', query: { source: 'c.123', mega_partner: '1' } },
+        { petition: 'megapartner_mayoptin', query: { source: 'c.imn.123' } },
+        { petition: 'megapartner_mayoptin', query: {} },
         { petition: 'mayoptin', query: { source: 'c.123' } } // No mailing_id
       ]
       const mockStoreAnon = createMockStore(storeAnonymous)
@@ -155,9 +156,8 @@ describe('<SignatureAddForm />', () => {
     })
     it('optin checkbox or hidden optin: show profiles', () => {
       const showProfiles = [
-        { petition: 'megapartner_mayoptin', query: { source: 'c.123', mailing_id: '123' } },
-        { petition: 'megapartner_mayoptin', query: { source: 's.imn', mega_partner: '1' } },
-        { petition: 'megapartner_mayoptin', query: {} },
+        { petition: 'megapartner_mayoptin', query: { source: 'c.imn.123', mailing_id: '123' } },
+        { petition: 'megapartner_mayoptin', query: { source: 's.imn' } },
         // Non-megapartner, but still may_optin: true
         { petition: 'mayoptin', query: { source: 'c.123', mailing_id: '123' } },
         { petition: 'mayoptin', query: { source: 's.abc' } }


### PR DESCRIPTION
This PR does two things.

1. The first is kinda silly, but instead of showing a 'raw' link to the petition to copy/paste, I create a shortcode link so we can track those -- more appropriate
2. The second was fixing the case of https://petitions.moveon.org/workingfamilies/sign/censure-trump-for-refusing and why it doesn't show a checkbox.

In the old code, I misunderstood the `$args->{mega_partner}` here:
https://github.com/MoveOnOrg/motrunk1/blob/soak/lib/MO/SignOn/PetitionApp.pm#L530
I thought that was for a query parameter.  However it's not -- it's loaded in for mega partners (in `www/pac/signon/dhandler` if you want to see) and then set there.  So it's basically equivalent to petition.mega_partner.....
which in our OSDI-ish api world, that is `creator.source`.
I change the tests to match the new understanding.