### PR TITLE
add moveon-petitions class on wrapper

### DIFF
--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -6,7 +6,7 @@ import Nav from './nav.js'
 import Footer from './footer.js'
 
 const Wrapper = ({ children, params }) => (
-  <div>
+  <div className='moveon-petitions'>
     <Nav organization={params && params.organization || ''} />
     <main className='main'>
       {children}


### PR DESCRIPTION
Fixes #173. Nav logo relies on moveon-petitions class, which was previously only wrapped around content, not nav. Since that class is on every page, just adding it to wrapper solves it. But not removing it from individual page components because some CSS selectors require the class to be on the same element as page-specific classes.