### PR TITLE
update HTML and CSS for signature pager links

### DIFF
--- a/css/moui.css
+++ b/css/moui.css
@@ -6961,7 +6961,7 @@ pre {
 }
 /**Anchors**/
 /** default anchor behaviors **/
-a:link,
+a,
 a:visited,
 a:hover {
   color: #193f92;

--- a/src/components/signature-list.js
+++ b/src/components/signature-list.js
@@ -48,14 +48,14 @@ class SignatureList extends React.Component {
     }
     const startNumber = ((page - 1) * 10) + 1
     const previousButton = ((page < 2) ? '' : (
-      <span className='previous'>
-        <a onClick={this.previousPage}>Previous</a>
-      </span>
+      <li className='previous'>
+        <a onClick={this.previousPage}>&lt; &lt; Previous</a>
+      </li>
     ))
     const nextButton = (((startNumber + 10) > signatureCount) ? '' :
-      <span className='next'>
-        <a onClick={this.nextPage}>Next</a>
-      </span>
+      <li className='next'>
+        <a onClick={this.nextPage}>Next &gt; &gt;</a>
+      </li>
     )
     return (
       <div>
@@ -63,10 +63,10 @@ class SignatureList extends React.Component {
           signatures={signatures[page]}
           startNumber={startNumber}
         />
-        <div className='pager'>
+        <ul className='pager'>
           {previousButton}
           {nextButton}
-        </div>
+        </ul>
       </div>
     )
   }


### PR DESCRIPTION
Fixes #183. I tried to avoid needing CSS updates, but the `a:link` selector doesn't attach to `<a>` tags without href, and href is hard (impossible?) to stop in React.

I also suspect both the empty `<a>` and the `&gt; &gt;` (matching the live site) are bad for accessibility, but we're redesigning soon anyway, so just sticking to the status quo for now.