### PR TITLE
allows us to deploy parts of the app with prodReady <Route /> property,...

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,8 @@
  * assuming redux-thunk, no mapPropsToDispatch -- just call `dipatch(actions.foo(data))`
  * `actions/*` is where you call out to get data (async or otherwise)
  * lazy-loading info: (TODO)
- 
-
+ * Even though convention calls redux 'state' 'state' -- we call it `store`, to map better to the redux
+   global store object, and distinguish it from component states.  c.f. any component that has a mapStateToProps function
+ * Any links to petitions.moveon.org should use react-router's `<Link to= />` regardless of it being in or out of the react app.
+   - The url must be absolute and not relative (start with a `/`)
+   - See src/routes.js for details -- when a route's app is 'production ready', we need to mark it with `prodReady` in the appropriate `<Route />`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@
  * Even though convention calls redux 'state' 'state' -- we call it `store`, to map better to the redux
    global store object, and distinguish it from component states.  c.f. any component that has a mapStateToProps function
  * Any links to petitions.moveon.org should use react-router's `<Link to= />` regardless of it being in or out of the react app.
-   - The url must be absolute and not relative (start with a `/`)
+   - The `to` must be an absolute path and not relative (i.e. start with a `/`)
    - See src/routes.js for details -- when a route's app is 'production ready', we need to mark it with `prodReady` in the appropriate `<Route />`

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -169,7 +169,7 @@ export const registerSignatureAndThanks = (petition, signature) => () => {
     window.gtag('event', 'conversion', { send_to: petition.gtag_keys })
   }
   // 2. show thanks page
-  let thanksUrl = 'thanks.html'
+  let thanksUrl = '/thanks.html'
   if (petition.thanks_url) {
     if (/^https?:\/\//.test(petition.thanks_url)) {
       document.location = petition.thanks_url // FUTURE: maybe add some query params

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router'
 
 const Footer = () => (
   <div className='container footer'>
@@ -11,19 +12,19 @@ const Footer = () => (
         </div>
         <div className='row'>
           <div className='span4'>
-            <a className='icon-start icon-link-narrow' href='https://petitions.moveon.org/create_start.html?source=bnav'>Start a Petition</a>
-            <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html'>Dashboard</a>
+            <Link className='icon-start icon-link-narrow' to='/create_start.html?source=bnav'>Start a Petition</Link>
+            <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html'>Dashboard</Link>
             <ul className='nav'>
               <li><a className='lh-14 navlink' href='/login/do_logout.html?redirect=/index.html'>Logout</a></li>
-              <li><a href='https://petitions.moveon.org/organizations.html'>Organizations</a></li>
+              <li><Link to='/organizations.html'>Organizations</Link></li>
               <li><a href='https://front.moveon.org/category/victories/'>Victories</a></li>
               <li><a href='https://civic.moveon.org/donatec4/creditcard.html?cpn_id=511'>Donate</a></li>
               <li><a href='https://act.moveon.org/survey/press'>Press</a></li>
-              <li><a href='https://petitions.moveon.org/feedback.html'>Contact</a></li>
+              <li><Link to='/feedback.html'>Contact</Link></li>
               <li><a href='https://front.moveon.org/blog/'>Blog</a></li>
-              <li><a href='https://petitions.moveon.org/login/register.html'>Sign Up</a></li>
-              <li><a href='https://petitions.moveon.org/privacy.html'>Privacy Policy</a></li>
-              <li><a href='https://petitions.moveon.org/terms.html'>Terms of Use</a></li>
+              <li><Link to='/login/register.html'>Sign Up</Link></li>
+              <li><Link to='/privacy.html'>Privacy Policy</Link></li>
+              <li><Link to='/terms.html'>Terms of Use</Link></li>
               <li><a href='https://front.moveon.org/careers'>Careers</a></li>
             </ul>
           </div>

--- a/src/components/nav-link.js
+++ b/src/components/nav-link.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { Link } from 'react-router'
 import PropTypes from 'prop-types'
 
 const NavLink = ({ to, children }) => (
-  <li><a className='lh-14 navlink' href={to}>{children}</a></li>
+  <li><Link className='lh-14 navlink' to={to}>{children}</Link></li>
 )
 
 NavLink.propTypes = {

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router'
 
 import NavLink from './nav-link'
 
-const Nav = ({ user, nav, organization }) => {
+const Nav = ({ user, nav, organization, minimal }) => {
   const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
 
   const userLinks = (
@@ -56,26 +56,29 @@ const Nav = ({ user, nav, organization }) => {
               <Link to='/'>MoveOn.org</Link>
             </div>
           </div>
+          {!minimal
+            ? ( // when not minimal, we have a bunch of links for you!
+            <div>
+              <div className='pull-left top-icons hidden-phone'>
+                <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
+                 {partnerLogoLinks}
+                </div>
+                <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav'>Start a petition</Link>
+                {user.given_name ? userDashboardLink : guestDashboardLink}
+              </div>
 
-          <div className='pull-left top-icons hidden-phone'>
-            <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
-              {partnerLogoLinks}
+              <div className='pull-left top-icons visible-phone'>
+                <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav-mobile' />
+                <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html' />
+              </div>
+
+              <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>
+                <span className='icon-th-list'></span>
+              </a>
+
+              {user.signonId ? userLinks : guestLinks}
             </div>
-            <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav'>Start a petition</Link>
-            {user.given_name ? userDashboardLink : guestDashboardLink}
-          </div>
-
-          <div className='pull-left top-icons visible-phone'>
-            <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav-mobile' />
-            <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html' />
-          </div>
-
-          <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>
-            <span className='icon-th-list'></span>
-          </a>
-
-          {user.signonId ? userLinks : guestLinks}
-
+            ) : null}
         </div>
       </div>
       <div className='container visible-phone'>
@@ -92,7 +95,8 @@ const Nav = ({ user, nav, organization }) => {
 Nav.propTypes = {
   user: PropTypes.object,
   nav: PropTypes.object,
-  organization: PropTypes.string
+  organization: PropTypes.string,
+  minimal: PropTypes.bool
 }
 
 function mapStateToProps(store) {

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { Link } from 'react-router'
 
 import NavLink from './nav-link'
 
@@ -30,16 +31,16 @@ const Nav = ({ user, nav, organization }) => {
   )
 
   const userDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</a>
+    <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html?source=topnav'> {`${user.given_name}’s`} Dashboard</Link>
   )
 
   const guestDashboardLink = (
-    <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html?source=topnav'>Manage Petitions</a>
+    <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html?source=topnav'>Manage Petitions</Link>
   )
 
   const partnerLogoLinks = (
     (cobrand)
-      ? (<a href={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></a>
+      ? (<Link to={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></Link>
         ) : null)
 
   return (
@@ -47,12 +48,12 @@ const Nav = ({ user, nav, organization }) => {
       <div className='container' id='header'>
         <div className='row'>
           <div className='moveon-masthead pull-left hidden-phone'>
-            <a href='/'>MoveOn.org</a>
+            <Link to='/'>MoveOn.org</Link>
           </div>
 
           <div className='mobile visible-phone'>
             <div className='moveon-masthead pull-left'>
-              <a href='/'>MoveOn.org</a>
+              <Link to='/'>MoveOn.org</Link>
             </div>
           </div>
 
@@ -60,13 +61,13 @@ const Nav = ({ user, nav, organization }) => {
             <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
               {partnerLogoLinks}
             </div>
-            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav'>Start a petition</a>
+            <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav'>Start a petition</Link>
             {user.given_name ? userDashboardLink : guestDashboardLink}
           </div>
 
           <div className='pull-left top-icons visible-phone'>
-            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav-mobile'></a>
-            <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html'></a>
+            <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav-mobile' />
+            <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html' />
           </div>
 
           <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>

--- a/src/components/petition-report.js
+++ b/src/components/petition-report.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router'
 import PropTypes from 'prop-types'
 
 import Sparkline from './sparkline'
@@ -21,7 +22,7 @@ const PetitionReport = ({ petition, signatureStats }) => (
             </tr>
             <tr>
               <td className='name'>URL</td>
-              <td><a href={`https://petitions.moveon.org/sign/${petition.name}`} target='_blank'>https://petitions.moveon.org/sign/{petition.name}</a></td>
+              <td><Link to={`/sign/${petition.name}`} target='_blank'>https://petitions.moveon.org/sign/{petition.name}</Link></td>
             </tr>
           </table>
 

--- a/src/components/search-result-pagination.js
+++ b/src/components/search-result-pagination.js
@@ -36,8 +36,8 @@ class SearchResultPagination extends React.Component {
     const nextPage = currentPage + 1
     const prevPage = Math.max(1, currentPage - 1)
 
-    const nextPageLinkUrl = `find?q=${q}&page=${nextPage}`
-    const prevPageLinkUrl = `find?q=${q}&page=${prevPage}`
+    const nextPageLinkUrl = `/find?q=${q}&page=${nextPage}`
+    const prevPageLinkUrl = `/find?q=${q}&page=${prevPage}`
 
     const numPages = Math.ceil(resultCount / pageSize)
     const pages = []

--- a/src/components/signature-add-form.js
+++ b/src/components/signature-add-form.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { Link } from 'react-router'
 
 import CountrySelect from './form/country-select'
 import StateOrRegionInput from './form/state-or-region-input'
@@ -383,11 +384,11 @@ class SignatureAddForm extends React.Component {
 
            {(this.props.showOptinWarning) ? (
              <p className='disclaimer bump-top-1'>
-               <b>Note:</b> This petition is a project of {creator.organization} and MoveOn.org. By signing, you agree to receive email messages from <span id='organization_receive'>{creator.organization}, </span>MoveOn Political Action, and MoveOn Civic Action. You may unsubscribe at any time. [<a href='https://petitions.moveon.org/privacy.html'>privacy policy</a>]
+               <b>Note:</b> This petition is a project of {creator.organization} and MoveOn.org. By signing, you agree to receive email messages from <span id='organization_receive'>{creator.organization}, </span>MoveOn Political Action, and MoveOn Civic Action. You may unsubscribe at any time. [<Link to='/privacy.html'>privacy policy</Link>]
              </p>)
             : (
              <p className='disclaimer bump-top-1'>
-               <b>Note:</b> By signing, you agree to receive email messages from MoveOn.org Civic Action and MoveOn.org Political Action. You may unsubscribe at any time. [ <a href='https://petitions.moveon.org/privacy.html'>Privacy policy</a> ]
+               <b>Note:</b> By signing, you agree to receive email messages from MoveOn.org Civic Action and MoveOn.org Political Action. You may unsubscribe at any time. [ <Link to='/privacy.html'>Privacy policy</Link> ]
              </p>)}
 
 

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -5,9 +5,12 @@ import PropTypes from 'prop-types'
 import Nav from './nav.js'
 import Footer from './footer.js'
 
-const Wrapper = ({ children, params }) => (
+const Wrapper = ({ children, params, routes }) => (
   <div className='moveon-petitions'>
-    <Nav organization={params && params.organization || ''} />
+    <Nav
+      organization={params && params.organization || ''}
+      minimal={!!routes[routes.length - 1].minimalNav}
+    />
     <main className='main'>
       {children}
     </main>
@@ -19,7 +22,8 @@ const Wrapper = ({ children, params }) => (
 
 Wrapper.propTypes = {
   children: PropTypes.object.isRequired,
-  params: PropTypes.object
+  params: PropTypes.object,
+  routes: PropTypes.object.isRequired
 }
 
 export default Wrapper

--- a/src/routes.js
+++ b/src/routes.js
@@ -61,7 +61,7 @@ export const routes = (store) => {
       <IndexRoute component={Home} />
       <Route path='/sign/:petition_slug' component={SignPetition} />
       <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
-      <Route path='/thanks.html' component={ThanksPage} prodReady minimalNav />
+      <Route path='/thanks.html' component={ThanksPage} prodReady={false} minimalNav />
       <Route path='/:organization/thanks.html' component={ThanksPage} onEnter={orgLoader} />
       <Route path='/find' component={SearchPage} />
       <Route path='/dashboard.html' component={PetitionCreatorDashboard} />

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IndexRoute, Route, Router, browserHistory, hashHistory } from 'react-router'
+import { IndexRoute, Route, Router, browserHistory, hashHistory, match } from 'react-router'
 
 
 import { Config } from './config'
@@ -19,27 +19,61 @@ const baseAppPath = process.env.BASE_APP_PATH || '/'
 
 export const appLocation = (Config.USE_HASH_BROWSING ? hashHistory : browserHistory)
 
+const updateHistoryObject = (historyObj, routes) => {
+  // This overrides <Link> routes and router.push() calls if we haven't implemented
+  // that view yet or if we're in production limits matches
+  // to <Route> objects marked with a prodReady property (={true})
+  // All <Link>s and appLocation.push calls in the codebase should NOT be relative
+  // -- i.e. they should be absolute links like /thanks.html
+
+  const PROD_URL = 'https://petitions.moveon.org'
+  const origPush = historyObj.push
+  // eslint-disable-next-line no-param-reassign
+  historyObj.push = (path, state) => {
+    match(
+      { location: path, routes },
+      (error, newlocation, props) => {
+        if (!error && props) {
+          const matchedComponent = props.routes[props.routes.length - 1]
+          if (matchedComponent.prodReady || Config.BASE_URL !== PROD_URL) {
+            origPush.call(this, path, state)
+            return
+          }
+        }
+        if (path.substring(0, 4) === 'http') {
+          window.location = path
+        } else {
+          window.location = `${PROD_URL}${path}`
+        }
+      })
+  }
+}
+
 export const routes = (store) => {
   const orgLoader = (nextState) => {
     if (nextState.params && nextState.params.organization) {
       store.dispatch(loadOrganization(nextState.params.organization))
     }
   }
+  const routeHierarchy = (
+    <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
+      <IndexRoute component={Home} />
+      <Route path='/sign/:petition_slug' component={SignPetition} />
+      <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
+      <Route path='/thanks.html' component={ThanksPage} prodReady />
+      <Route path='/:organization/thanks.html' component={ThanksPage} onEnter={orgLoader} />
+      <Route path='/find' component={SearchPage} />
+      <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
+      <Route path='/create_start.html' component={CreatePetitionPage} />
+      <Route path='/petition_report.html' component={PetitionReportPage} />
+      <Route path='/:organization/create_start.html' component={CreatePetitionPage} onEnter={orgLoader} />
+      <Route path='/:organization/' component={Home} onEnter={orgLoader} />
+    </Route>
+  )
+  updateHistoryObject(appLocation, routeHierarchy)
   return (
     <Router history={appLocation}>
-      <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
-        <IndexRoute component={Home} />
-        <Route path='/sign/:petition_slug' component={SignPetition} />
-        <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
-        <Route path='/thanks.html' component={ThanksPage} />
-        <Route path='/:organization/thanks.html' component={ThanksPage} onEnter={orgLoader} />
-        <Route path='/find' component={SearchPage} />
-        <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
-        <Route path='/create_start.html' component={CreatePetitionPage} />
-        <Route path='/petition_report.html' component={PetitionReportPage} />
-        <Route path='/:organization/create_start.html' component={CreatePetitionPage} onEnter={orgLoader} />
-        <Route path='/:organization/' component={Home} onEnter={orgLoader} />
-      </Route>
+      {routeHierarchy}
     </Router>
   )
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -60,11 +60,11 @@ export const routes = (store) => {
       <IndexRoute component={Home} />
       <Route path='/sign/:petition_slug' component={SignPetition} />
       <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
-      <Route path='/thanks.html' component={ThanksPage} prodReady />
+      <Route path='/thanks.html' component={ThanksPage} prodReady minimalNav />
       <Route path='/:organization/thanks.html' component={ThanksPage} onEnter={orgLoader} />
       <Route path='/find' component={SearchPage} />
       <Route path='/dashboard.html' component={PetitionCreatorDashboard} />
-      <Route path='/create_start.html' component={CreatePetitionPage} />
+      <Route path='/create_start.html' component={CreatePetitionPage} minimalNav />
       <Route path='/petition_report.html' component={PetitionReportPage} />
       <Route path='/:organization/create_start.html' component={CreatePetitionPage} onEnter={orgLoader} />
       <Route path='/:organization/' component={Home} onEnter={orgLoader} />

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,7 +25,7 @@ const updateHistoryObject = (historyObj, routes) => {
   // that view yet or if we're in production limits matches
   // to <Route> objects marked with a prodReady property (={true})
   // All <Link>s and appLocation.push calls in the codebase should NOT be relative
-  // -- i.e. they should be absolute links like /thanks.html
+  // -- i.e. they should be absolute paths like /thanks.html
 
   const PROD_URL = 'https://petitions.moveon.org'
   const origPush = historyObj.push

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,8 @@ var config = {
         'API_WRITABLE': JSON.stringify(process.env.API_WRITABLE || process.env.PROD),
         'API_SIGN_PETITION': JSON.stringify(process.env.API_SIGN_PETITION || ''),
         'BASE_APP_PATH': JSON.stringify(process.env.BASE_APP_PATH || '/'),
-        'BASE_URL': JSON.stringify(process.env.BASE_URL || 'https://petitions.moveon.org'),
+        'BASE_URL': JSON.stringify(process.env.BASE_URL
+                                   || (process.env.PROD ? 'https://petitions.moveon.org' : '')),
         'SESSION_COOKIE_NAME': JSON.stringify(process.env.SESSION_COOKIE_NAME || 'SO_SESSION'),
         'STATIC_ROOT': JSON.stringify(process.env.STATIC_ROOT || ''),
         'TRACK_SHARE_URL': JSON.stringify(process.env.TRACK_SHARE_URL || ''),


### PR DESCRIPTION
...,but make ALL petitions.moveon.org links use <Link to= /> and then direct appropriately.

This should make it straightforward for us to distinguish what's 'done and ready' and still being worked on and allow us to deploy production pieces that have passed while some still-not-complete (or QA/tested) components, can still live in master with their routes.

This now also has a second commit -- see https://github.com/MoveOnOrg/mop-frontend/pull/200/commits/8825c11060837662462d1d1a8e516d82ae5e7047 for the second one, which fixes #201 and fixes #63