### PR TITLE
minimal nav feature based on property in route

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { Link } from 'react-router'
 
 import NavLink from './nav-link'
 
-const Nav = ({ user, nav, organization }) => {
+const Nav = ({ user, nav, organization, minimal }) => {
   const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
 
   const userLinks = (
@@ -56,24 +57,29 @@ const Nav = ({ user, nav, organization }) => {
             </div>
           </div>
 
-          <div className='pull-left top-icons hidden-phone'>
-            <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
-              {partnerLogoLinks}
+          {!minimal
+            ? ( // when not minimal, we have a bunch of links for you!
+            <div>
+              <div className='pull-left top-icons hidden-phone'>
+                <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
+                 {partnerLogoLinks}
+                </div>
+                <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav'>Start a petition</Link>
+                {user.given_name ? userDashboardLink : guestDashboardLink}
+              </div>
+
+              <div className='pull-left top-icons visible-phone'>
+                <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav-mobile' />
+                <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html' />
+              </div>
+
+              <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>
+                <span className='icon-th-list'></span>
+              </a>
+
+              {user.signonId ? userLinks : guestLinks}
             </div>
-            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav'>Start a petition</a>
-            {user.given_name ? userDashboardLink : guestDashboardLink}
-          </div>
-
-          <div className='pull-left top-icons visible-phone'>
-            <a className='icon-link-narrow icon-start' href='https://petitions.moveon.org/create_start.html?source=topnav-mobile'></a>
-            <a className='icon-link-narrow icon-managepetitions' href='https://petitions.moveon.org/dashboard.html'></a>
-          </div>
-
-          <a className='btn visible-phone pull-right bump-top-2' data-toggle='collapse' data-target='.nav-collapse'>
-            <span className='icon-th-list'></span>
-          </a>
-
-          {user.signonId ? userLinks : guestLinks}
+            ) : null}
 
         </div>
       </div>
@@ -91,7 +97,8 @@ const Nav = ({ user, nav, organization }) => {
 Nav.propTypes = {
   user: PropTypes.object,
   nav: PropTypes.object,
-  organization: PropTypes.string
+  organization: PropTypes.string,
+  minimal: PropTypes.bool
 }
 
 function mapStateToProps(store) {

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -5,9 +5,12 @@ import PropTypes from 'prop-types'
 import Nav from './nav.js'
 import Footer from './footer.js'
 
-const Wrapper = ({ children, params }) => (
+const Wrapper = ({ children, params, routes }) => (
   <div className='moveon-petitions'>
-    <Nav organization={params && params.organization || ''} />
+    <Nav
+      organization={params && params.organization || ''}
+      minimal={!!routes[routes.length - 1].minimalNav}
+    />
     <main className='main'>
       {children}
     </main>
@@ -19,7 +22,8 @@ const Wrapper = ({ children, params }) => (
 
 Wrapper.propTypes = {
   children: PropTypes.object.isRequired,
-  params: PropTypes.object
+  params: PropTypes.object,
+  routes: PropTypes.object.isRequired
 }
 
 export default Wrapper


### PR DESCRIPTION
This will help with   #201 and  #63
but will wait until #224 lands, and then we can add the `minimalNav` property to routes.js on /thanks and /create_start without a merge conflict.

(Originally connected in #200)