### PR TITLE
Correct PropType for Wrapper

### DIFF
--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -23,7 +23,7 @@ const Wrapper = ({ children, params, routes }) => (
 Wrapper.propTypes = {
   children: PropTypes.object.isRequired,
   params: PropTypes.object,
-  routes: PropTypes.object.isRequired
+  routes: PropTypes.array.isRequired
 }
 
 export default Wrapper


### PR DESCRIPTION
This was throwing a warning for me, and we access `props.routes` as an array, so I think it was just a typo