### PR TITLE
Setup for giraffe tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '6.1'
 script:
   - npm run lint
-  - npm run test
+  - THEME=legacy npm run test
   - THEME=giraffe npm run test
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
 - '6.1'
-script: npm run lint-and-test
+script:
+  - npm run lint
+  - npm run test
+  - THEME=giraffe npm run test
 notifications:
   slack:
     rooms:

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/MoveOnOrg/mop-frontend",
   "directories": {},
   "scripts": {
-    "test": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch test test/*",
-    "test1": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch test ",
+    "test": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test test/*",
+    "test1": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test ",
     "build": "webpack && THEME=giraffe webpack",
     "dev-build": "webpack -d && THEME=giraffe webpack -d",
     "webpack-watch": "webpack -w",
@@ -63,6 +63,7 @@
     "react-test-renderer": "^15.5.4",
     "redux-mock-store": "^1.2.3",
     "redux-test-utils": "^0.2.2",
+    "require-hacker": "^3.0.1",
     "sinon": "^4.2.2",
     "svg-react-loader": "^0.4.5",
     "webpack": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test test/*",
     "test1": "NODE_ENV=test mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test ",
-    "build": "webpack && THEME=giraffe webpack",
-    "dev-build": "webpack -d && THEME=giraffe webpack -d",
+    "build": "THEME=legacy webpack && THEME=giraffe webpack",
+    "dev-build": "THEME=legacy webpack -d && THEME=giraffe webpack -d",
     "webpack-watch": "webpack -w",
     "dev": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --progress --colors --port ${PORT:-8080} --inline",
     "lint": "eslint src test .*.js --ignore-pattern='!.eslintrc.js' ",

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,4 @@
+import requireHacker from 'require-hacker'
+
+// Replace svgs with empty react components
+requireHacker.hook('svg', () => 'module.exports = () => null')

--- a/test/components/giraffe-nav.js
+++ b/test/components/giraffe-nav.js
@@ -1,13 +1,35 @@
 import React from 'react'
 import { expect } from 'chai'
 
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 
 import Nav from '../../src/components/theme-giraffe/nav'
 
+import { Primary, Secondary, MoNav } from 'GiraffeUI/nav'
+
+const props = { openSections: [], toggleSection: () => {} }
+
 describe('<Nav /> (Giraffe)', () => {
   it('renders <Header />', () => {
-    const nav = shallow(<Nav />)
-    expect(nav.find('Header').length).to.equal(1)
+    const header = shallow(<Nav {...props} />)
+    expect(header.find('Header').length).to.equal(1)
+  })
+
+  it('renders Sections in the Primary Nav', () => {
+    const header = mount(<Nav {...props} />)
+    const nav = header.find(MoNav)
+    const primary = nav.find(Primary)
+    expect(primary.length).to.equal(1)
+    const sections = primary.find(Primary.Section)
+    expect(sections.length).to.equal(2)
+  })
+
+  it('renders Top and Bottom within Secondary', () => {
+    const header = mount(<Nav {...props} />)
+    const nav = header.find(MoNav)
+    const sec = nav.find(Secondary)
+    expect(sec.length).to.equal(1)
+    expect(sec.find(Secondary.Top).length).to.equal(1)
+    expect(sec.find(Secondary.Bottom).length).to.equal(1)
   })
 })

--- a/test/components/giraffe-nav.js
+++ b/test/components/giraffe-nav.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { expect } from 'chai'
+
+import { shallow } from 'enzyme'
+
+import Nav from '../../src/components/theme-giraffe/nav'
+
+describe('<Nav /> (Giraffe)', () => {
+  it('renders <Header />', () => {
+    const nav = shallow(<Nav />)
+    expect(nav.find('Header').length).to.equal(1)
+  })
+})


### PR DESCRIPTION
Does two things:

1. Makes travis run tests twice, once with the legacy theme, once with giraffe theme. It's kind of annoying to have to run tests twice, but I don't see a way around it. If we want to build two javascript files, we should run tests for both.

2. Uses `require-hacker` to make importing SVGs work by replacing them with null components in tests.