### PR TITLE
move travis stage target to match our naming scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_deploy:
   - export BASE_APP_PATH="/"
   - export BASE_URL="https://broom.moveon.org"
   - export SESSION_COOKIE_NAME="SO_DEV_SESSION"
-  - export PUBLIC_ROOT="https://s3.us-west-1.amazonaws.com/mop-static-stage/js/"
+  - export PUBLIC_ROOT="https://s3.us-west-1.amazonaws.com/mop-static-stage/mop-frontend/js/"
   - export STATIC_ROOT=""
   - export PROD=1
   - export ONLY_PROD_ROUTES=1
@@ -29,6 +29,6 @@ deploy:
   skip_cleanup: true
   acl: public_read
   local_dir: build
-  upload-dir: js
+  upload-dir: mop-frontend/js
   secret_access_key:
     secure: MEjfUinb8RC50nEHxvnisYoBL15qjZoizNdBUjJ5OThiRQnGNRtiTgbdr1qeC4E2ZZ4Nzc9viNTyBhbRmZ3GViaAIeQ5RlFmL0JP/mXwOdgwJO3lE1ZksZWszrmJVaFSsq2BVlFG5O40Y3kVNmNUdlBOgFVRg8AJzefADIKRXBnf6Td07/36ETG5/lSIBNkLeercN9w5aD49tH5LJp8p83N08A6IDLj09xNdCiazN/yyHDD1KGFvDNQeKMFO5T7gBiywy2mHncTos8CX6gOE/yi3rE8qWirfFKyVVEQqVmbulZnmVxYQPmbJ8UMN3g/FOrhtm1r9fBXslSRKlPP1i4Vb0o6kh4IROkd/mU9cNdEokDqUyCT3NVqPdXd0fisk6Tu/krboHmC+fW6bu1KI1KHNfmg1ltp8FjLykeBVxyUjAxUmlCCepOOEBwsi5U2N0jixbT8cwX9e4++dryuo7LIOm2IPO/10LvhYSGEQgntyKB5g/yiEsw6RGEM3oFwkagfLDR16Fw/RGSYl0ikB2FYVZkN+J6kLMTzhvQwl4iIc5wRswz+ntnuFZlLxV2wKgpd5YBHD6KtN+/4G5O7NaDvJ/xwWQx7rJKDbLji4n+u/+OKIoFJ4cKoM7tyBscFo1jEXQfnuvAQRls3/vxKnFdTx0IPi16FOEz2uiJsA2Tg=

--- a/src/routes.js
+++ b/src/routes.js
@@ -64,7 +64,7 @@ export const routes = (store) => {
     }
   }
   const routeHierarchy = (
-    <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
+    <Route path={window.baseAppPath || baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
       <IndexRoute component={Home} />
       <Route path='/sign/:petition_slug' component={SignPetition} />
       <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />

--- a/src/routes.js
+++ b/src/routes.js
@@ -65,7 +65,7 @@ export const routes = (store) => {
   }
   const routeHierarchy = (
     <Route path={window.baseAppPath || baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
-      <IndexRoute component={Home} />
+      <IndexRoute prodReady component={Home} />
       <Route path='/sign/:petition_slug' component={SignPetition} />
       <Route path='/:organization/sign/:petition_slug' component={SignPetition} onEnter={orgLoader} />
       <Route path='/thanks.html' component={ThanksShim} prodReady={false} minimalNav />


### PR DESCRIPTION
This PR is a public service announcement to the 'new regime' on static deployment.

Basically giraffe, mop static files, mop-frontend (along with css/moui.css) need to be deployed to different places on mop-static-stage and on production they will go to the same places on static.moveon.org s3 bucket.

We will need to retire mop-static s3 bucket at some point.