### PR TITLE
Add static.moveon.org as static_root on stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_deploy:
   - export BASE_URL="https://broom.moveon.org"
   - export SESSION_COOKIE_NAME="SO_DEV_SESSION"
   - export PUBLIC_ROOT="https://s3.us-west-1.amazonaws.com/mop-static-stage/mop-frontend/js/"
-  - export STATIC_ROOT=""
+  - export STATIC_ROOT="https://static.moveon.org/giraffe/"
   - export PROD=1
   - export ONLY_PROD_ROUTES=1
   - npm run dev-build


### PR DESCRIPTION
I originally had this in https://github.com/MoveOnOrg/mop-frontend/pull/291/commits/2ec10f4a028d5013c6cd2acd80fc6d6a6d2ebb54, but I accidentally deleted it in a merge conflict