### PR TITLE
Warn about redux state modifications in dispatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-addons-test-utils": "^15.4.2",
     "react-sparklines": "^1.7.0",
     "react-test-renderer": "^15.5.4",
+    "redux-immutable-state-invariant": "^2.1.0",
     "redux-mock-store": "^1.2.3",
     "redux-test-utils": "^0.2.2",
     "require-hacker": "^3.0.1",

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,13 +1,18 @@
 import { createStore, compose, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
+import reduxImmutableStateInvariant from 'redux-immutable-state-invariant'
 
 import rootReducer from '../reducers'
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+
+const middleware = process.env.NODE_ENV !== 'production' ?
+  [reduxImmutableStateInvariant(), thunk] :
+  [thunk]
 export default function configureStore(initialState) {
   return createStore(
     rootReducer,
     initialState,
-    composeEnhancers(applyMiddleware(thunk))
+    composeEnhancers(applyMiddleware(...middleware))
   )
 }


### PR DESCRIPTION
See https://github.com/leoasis/redux-immutable-state-invariant

Only included in development.

> Redux middleware that spits an error on you when you try to mutate your state either inside a dispatch or between dispatches. For development use only!

>Because you're not allowed to mutate your state in your reducers!

I tested it out and without @lady3bean's bug fix in https://github.com/MoveOnOrg/mop-frontend/pull/302, and we would have seen this error when clicking into the petition sign page:

```
browser.js:40 Uncaught Error: A state mutation was detected inside a dispatch, in the path: 
`petitionStore.petitions.95983.slug`. Take a look at the reducer(s) handling the action
{"type":"FETCH_PETITION_SUCCESS","petition":{...}.
(http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)
```