### PR TITLE
Add giraffe mobile signing modal

### DIFF
--- a/src/components/theme-giraffe/petition.js
+++ b/src/components/theme-giraffe/petition.js
@@ -20,7 +20,8 @@ const Petition = ({
   petitionBy,
   outOfDate,
   isSignModalOpen,
-  openModal,
+  onClickFloatingSign,
+  setRef,
   closeModal
 }) => (
   <div className='mo-container'>
@@ -61,9 +62,11 @@ const Petition = ({
       </Details>
     </InfoColumn>
     <SignColumn>
-      <SignatureAddForm petition={p} query={query} />
+      <SignatureAddForm setRef={setRef} petition={p} query={query} />
     </SignColumn>
-    <button onClick={openModal} className='sign-form__modal-toggle'>Sign Now</button>
+    <button onClick={onClickFloatingSign} className='sign-form__modal-toggle'>
+      Sign Now
+    </button>
     <Modal
       heading='Sign Now'
       className='sign-form-modal'
@@ -81,8 +84,9 @@ Petition.propTypes = {
   petitionBy: PropTypes.string,
   outOfDate: PropTypes.string,
   isSignModalOpen: PropTypes.bool,
-  openModal: PropTypes.func,
-  closeModal: PropTypes.func
+  onClickFloatingSign: PropTypes.func,
+  closeModal: PropTypes.func,
+  setRef: PropTypes.func
 }
 
 export default Petition

--- a/src/components/theme-giraffe/petition.js
+++ b/src/components/theme-giraffe/petition.js
@@ -8,12 +8,21 @@ import {
   SignColumn,
   InfoColumn
 } from 'GiraffeUI/petition'
+import { Modal } from 'GiraffeUI/modal'
 
 import { text2paraJsx, splitIntoSpansJsx, ellipsize } from '../../lib'
 import SignatureAddForm from '../../containers/signature-add-form'
 import SignatureList from '../../containers/signature-list'
 
-const Petition = ({ petition: p, query, petitionBy, outOfDate }) => (
+const Petition = ({
+  petition: p,
+  query,
+  petitionBy,
+  outOfDate,
+  isSignModalOpen,
+  openModal,
+  closeModal
+}) => (
   <div className='mo-container'>
     <Message outOfDate={outOfDate} petition={p} isFwd={query.fwd} />
     <InfoColumn>
@@ -54,6 +63,15 @@ const Petition = ({ petition: p, query, petitionBy, outOfDate }) => (
     <SignColumn>
       <SignatureAddForm petition={p} query={query} />
     </SignColumn>
+    <button onClick={openModal} className='sign-form__modal-toggle'>Sign Now</button>
+    <Modal
+      heading='Sign Now'
+      className='sign-form-modal'
+      onClose={closeModal}
+      visible={isSignModalOpen}
+    >
+      <SignatureAddForm petition={p} query={query} />
+    </Modal>
   </div>
 )
 
@@ -61,7 +79,10 @@ Petition.propTypes = {
   petition: PropTypes.object.isRequired,
   query: PropTypes.object,
   petitionBy: PropTypes.string,
-  outOfDate: PropTypes.string
+  outOfDate: PropTypes.string,
+  isSignModalOpen: PropTypes.bool,
+  openModal: PropTypes.func,
+  closeModal: PropTypes.func
 }
 
 export default Petition

--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -23,7 +23,8 @@ const SignatureAddForm = ({
   onUnrecognize,
   updateStateFromValue,
   getValueFromState: getValue,
-  validationError
+  validationError,
+  setRef
 }) => (
   <form onSubmit={submit} className='sign-form'>
     <h4>SIGN THIS PETITION</h4>
@@ -42,6 +43,7 @@ const SignatureAddForm = ({
         <InputBlock
           name='name'
           label='Name*'
+          setRef={setRef}
           value={getValue('name')}
           onChange={updateStateFromValue('name')}
         />
@@ -69,6 +71,7 @@ const SignatureAddForm = ({
           label={requireAddressFields ? 'Address*' : 'Address'}
           onChange={updateStateFromValue('address1')}
           value={getValue('address1')}
+          setRef={setRef}
         />
         {validationError('address1')}
         <InputBlock
@@ -125,6 +128,7 @@ const SignatureAddForm = ({
         autoComplete='off'
         onChange={updateStateFromValue('comment')}
         onBlur={updateStateFromValue('comment')}
+        ref={setRef}
       />
     </InputBlock>
 
@@ -217,7 +221,8 @@ SignatureAddForm.propTypes = {
   onChangeCountry: PropTypes.func,
   updateStateFromValue: PropTypes.func,
   getValueFromState: PropTypes.func,
-  validationError: PropTypes.func
+  validationError: PropTypes.func,
+  setRef: PropTypes.func
 }
 
 export default SignatureAddForm

--- a/src/containers/sign-petition.js
+++ b/src/containers/sign-petition.js
@@ -12,10 +12,14 @@ class SignPetition extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      isSignModalOpen: false
+      isSignModalOpen: false,
+      width: 0
     }
+    this.setRef = this.setRef.bind(this)
     this.openModal = this.openModal.bind(this)
     this.closeModal = this.closeModal.bind(this)
+    this.onClickFloatingSign = this.onClickFloatingSign.bind(this)
+    this.updateWindowDimensions = this.updateWindowDimensions.bind(this)
   }
 
   componentWillMount() {
@@ -26,6 +30,31 @@ class SignPetition extends React.Component {
   componentDidMount() {
     // Lazy-load thanks page component
     thanksLoader()
+    this.updateWindowDimensions()
+    window.addEventListener('resize', this.updateWindowDimensions)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateWindowDimensions)
+  }
+
+  onClickFloatingSign() {
+    // if we are at the mobile breakpoint, show the modal
+    // otherwise, focus the form.
+    if (this.state.width < 768) {
+      this.openModal()
+    } else {
+      const firstInput = this.nameInput || this.countryInput || this.commentInput
+      if (firstInput) firstInput.focus()
+    }
+  }
+
+  setRef(input) {
+    return input && (this[`${input.name}Input`] = input)
+  }
+
+  updateWindowDimensions() {
+    this.setState({ width: window.innerWidth })
   }
 
   openModal() {
@@ -58,7 +87,8 @@ class SignPetition extends React.Component {
           petitionBy={petitionBy}
           outOfDate={outOfDate}
           isSignModalOpen={this.state.isSignModalOpen}
-          openModal={this.openModal}
+          onClickFloatingSign={this.onClickFloatingSign}
+          setRef={this.setRef}
           closeModal={this.closeModal}
         />
       </div>

--- a/src/containers/sign-petition.js
+++ b/src/containers/sign-petition.js
@@ -9,6 +9,14 @@ import { thanksLoader } from '../loaders/petition.js'
 import { actions as petitionActions } from '../actions/petitionActions.js'
 
 class SignPetition extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isSignModalOpen: false
+    }
+    this.openModal = this.openModal.bind(this)
+    this.closeModal = this.closeModal.bind(this)
+  }
 
   componentWillMount() {
     const { dispatch, params } = this.props
@@ -18,6 +26,14 @@ class SignPetition extends React.Component {
   componentDidMount() {
     // Lazy-load thanks page component
     thanksLoader()
+  }
+
+  openModal() {
+    this.setState({ isSignModalOpen: true })
+  }
+
+  closeModal() {
+    this.setState({ isSignModalOpen: false })
   }
 
   render() {
@@ -41,6 +57,9 @@ class SignPetition extends React.Component {
           query={this.props.location.query}
           petitionBy={petitionBy}
           outOfDate={outOfDate}
+          isSignModalOpen={this.state.isSignModalOpen}
+          openModal={this.openModal}
+          closeModal={this.closeModal}
         />
       </div>
     )

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -207,7 +207,7 @@ class SignatureAddForm extends React.Component {
   }
 
   render() {
-    const { dispatch, petition, user, query, showAddressFields, requireAddressFields, showOptinCheckbox, showOptinWarning } = this.props
+    const { dispatch, petition, user, query, showAddressFields, requireAddressFields, showOptinCheckbox, showOptinWarning, setRef } = this.props
     const creator = (petition._embedded && petition._embedded.creator || {})
     const petitionBy = creator.name + (creator.organization
                                        ? `, ${creator.organization}`
@@ -237,6 +237,7 @@ class SignatureAddForm extends React.Component {
         }
         showOptinWarning={showOptinWarning}
         showOptinCheckbox={showOptinCheckbox}
+        setRef={setRef}
       />
     )
   }
@@ -254,7 +255,8 @@ SignatureAddForm.propTypes = {
   fromMailing: PropTypes.bool,
   showOptinWarning: PropTypes.bool,
   showOptinCheckbox: PropTypes.bool,
-  hiddenOptin: PropTypes.bool
+  hiddenOptin: PropTypes.bool,
+  setRef: PropTypes.func
 }
 
 function mapStateToProps(store, ownProps) {

--- a/src/giraffe-ui/modal.js
+++ b/src/giraffe-ui/modal.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import CloseSvg from './svgs/close.svg'
+
+export const Modal = ({ heading, children, className, visible, onClose }) => (
+  <div
+    className={`mo-modal ${className}`}
+    style={visible ? { display: 'block' } : {}}
+  >
+    <div className='mo-modal__backdrop' />
+
+    <div className='mo-modal__frame'>
+      <div className='mo-modal__dialog'>
+        <div className='mo-modal__content'>
+          <div className={`${className}__heading`}>{heading}</div>
+          {children}
+        </div>
+      </div>
+
+      <button className='mo-modal__close' onClick={onClose}>
+        <CloseSvg />
+      </button>
+    </div>
+  </div>
+)
+
+Modal.propTypes = {
+  heading: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  visible: PropTypes.bool,
+  onClose: PropTypes.func
+}

--- a/src/giraffe-ui/petition/input-block.js
+++ b/src/giraffe-ui/petition/input-block.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-export const InputBlock = ({ name, children, value, label, onChange, type, className }) => (
+export const InputBlock = ({ name, children, value, label, onChange, type, className, setRef }) => (
   <div className={cx('input-block', className, { active: !!value })}>
     {children || <input
       type={type}
@@ -10,6 +10,7 @@ export const InputBlock = ({ name, children, value, label, onChange, type, class
       name={name}
       onChange={onChange}
       onBlur={onChange}
+      ref={setRef}
     />}
     <label htmlFor={name}>{label}</label>
   </div>
@@ -24,5 +25,6 @@ InputBlock.propTypes = {
   label: PropTypes.string.isRequired,
   type: PropTypes.string,
   onChange: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  setRef: PropTypes.func
 }


### PR DESCRIPTION
Adds the fixed-position "sign now" button, and the signing modal that is used for mobile petition signing.

On desktop, instead of showing the modal, we focus the sign form.

Tracking issue #309

- [x] The modal should only appear on mobile, otherwise focus the form