### PR TITLE
Rewrite history match location in include baseAppPath

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -40,7 +40,7 @@ const updateHistoryObject = (historyObj, routes) => {
   // eslint-disable-next-line no-param-reassign
   historyObj.push = (path, state) => {
     let matchPath = path
-    if (baseAppPath !== '/') {
+    if (baseAppPath !== '/' && path.substring(0, 4) !== 'http') {
       matchPath = baseAppPath + (path[0] === '/' ? path.substring(1) : path)
     }
     match(


### PR DESCRIPTION
This uses our overwritten <Link> routes and router.push() matcher to rewrites match locations to include baseAppPath (like /2018/). This means you should stay within the baseAppPath you originally accessed.

If a route is not found or not prodReady, we redirect using the original path  like petitions.moveon.org/thanks.html (without /2018/)

Fixes #343 