### PR TITLE
Use browser routing by default in dev

### DIFF
--- a/docs/REFERENCE--environment_variables.md
+++ b/docs/REFERENCE--environment_variables.md
@@ -13,5 +13,6 @@ SESSION_COOKIE_NAME               | When this cookie is present, user session da
 STATIC_ROOT                       | For WebPack dev server, the relative path from initial page load to JS and other static assets. _Default_: "".
 TRACK_SHARE_URL                   | A url endpoint that share events (e.g. from thanks page) should be sent to with details about the shared page.  (see `src/actions/petitionActions.js`). _Default_: "" (none).
 THEME                             | Controls whether `import A from "Theme/a"` comes from the "theme-giraffe" or "theme-legacy" components. ("giraffe" or "legacy") _Default_: "legacy"
+USE_HASH_BROWSING                 | Whether you want to use react-router HashHistory _Default_: false
 LOCAL_REACT                       | Dev only: a path with react.js and react-dom.js, if you want to develop offline _Default_: Loads react from unpkg.com CDN
 LOCAL_CSS                         | Dev only: a theme-giraffe style.css. E.g. `http://localhost:3000/styles/main.css`, as served by `gulp watch` in the giraffe repo, so you can change css and/or develop offline. _Default_: Loads css from the mop-static-stage s3 bucket

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ export const Config = {
   ONLY_PROD_ROUTES: process.env.ONLY_PROD_ROUTES || '',
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',
-  USE_HASH_BROWSING: !process.env.PROD,
+  USE_HASH_BROWSING: process.env.USE_HASH_BROWSING,
   ENTITY: process.env.ENTITY || window.ENTITY,
   STATIC_ROOT: process.env.STATIC_ROOT,
   WORDPRESS_API_URI: process.env.WORDPRESS_API_URI

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,9 @@ var config = {
   },
   devServer: {
     host: "0.0.0.0",
+    historyApiFallback: {
+      disableDotRule: true
+    }
   },
   devtool: 'sourcemap',
   output: {
@@ -92,6 +95,7 @@ var config = {
         'SESSION_COOKIE_NAME': JSON.stringify(process.env.SESSION_COOKIE_NAME || 'SO_SESSION'),
         'STATIC_ROOT': JSON.stringify(process.env.STATIC_ROOT || '/local/'),
         'TRACK_SHARE_URL': JSON.stringify(process.env.TRACK_SHARE_URL || ''),
+        'USE_HASH_BROWSING': JSON.stringify(process.env.USE_HASH_BROWSING || false),
         'PROD': process.env.PROD
       }
     })


### PR DESCRIPTION
It's good because it matches production more closely.

Will default to browser routing in dev and prod.