### PR TITLE
Show only 50 states in petition target dropdown

### DIFF
--- a/src/components/theme-legacy/form/state-select.js
+++ b/src/components/theme-legacy/form/state-select.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { states, armedForcesRegions } from '../../../lib/state-abbrev'
+import { getRegions, armedForcesRegions } from '../../../lib'
 
 const StateSelect = ({
   onChange,
@@ -8,28 +8,33 @@ const StateSelect = ({
   style,
   name = 'state',
   id = 'state_id',
-  className = 'span4 state moveon-track-click margin-right-1'
-}) => (
-  <select
-    name={name}
-    id={id}
-    className={className}
-    onChange={onChange}
-    style={style}
-  >
-    <option value=''>{selectText}</option>
-      {Object.keys(states).map(val => (
+  className = 'span4 state moveon-track-click margin-right-1',
+  onlyStates = false
+}) => {
+  const regions = getRegions(onlyStates)
+  return (
+    <select
+      name={name}
+      id={id}
+      className={className}
+      onChange={onChange}
+      style={style}
+    >
+      <option value=''>{selectText}</option>
+      {regions.map(([val, text]) => (
         <option key={val} value={val}>
-          {states[val]}
-        </option>
-      ))}
-      {armedForcesRegions.map(([val, text]) => (
-        <option key={text} value={val}>
           {text}
         </option>
       ))}
-  </select>
-)
+      {!onlyStates &&
+        armedForcesRegions.map(([val, text]) => (
+          <option key={text} value={val}>
+            {text}
+          </option>
+        ))}
+    </select>
+  )
+}
 
 StateSelect.propTypes = {
   onChange: PropTypes.func,
@@ -37,7 +42,8 @@ StateSelect.propTypes = {
   selectText: PropTypes.string,
   name: PropTypes.string,
   id: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  onlyStates: PropTypes.bool
 }
 
 export default StateSelect

--- a/src/components/theme-legacy/form/target-select/state.js
+++ b/src/components/theme-legacy/form/target-select/state.js
@@ -10,6 +10,7 @@ const StateTargetSelect = () => (
         name='select_target_state'
         id='state'
         className=''
+        onlyStates
       />
     </div>
     <div id='state_group_checkboxes'>

--- a/src/giraffe-ui/petition/state-select.js
+++ b/src/giraffe-ui/petition/state-select.js
@@ -1,24 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { states, armedForcesRegions } from '../../lib/state-abbrev'
+import { getRegions, armedForcesRegions } from '../../lib'
 
 import CaretDownSvg from '../svgs/caret-down.svg'
 
-export const StateSelect = ({ value, onChange, className }) => (
+export const StateSelect = ({ value, onChange, className, onlyStates }) => (
   <div className={cx('input-block', className, { active: !!value })}>
     <select name='state' id='state' className={className} onChange={onChange}>
-      <option></option>
-      {Object.keys(states).map(val => (
+      <option />
+      {getRegions(onlyStates).map(([val, text]) => (
         <option key={val} value={val}>
-          {states[val]}
-        </option>
-      ))}
-      {armedForcesRegions.map(([val, text]) => (
-        <option key={text} value={val}>
           {text}
         </option>
       ))}
+      {!onlyStates &&
+        armedForcesRegions.map(([val, text]) => (
+          <option key={text} value={val}>
+            {text}
+          </option>
+        ))}
     </select>
     <CaretDownSvg className='select-caret' />
     <label htmlFor='country'>State*</label>
@@ -28,5 +29,6 @@ export const StateSelect = ({ value, onChange, className }) => (
 StateSelect.propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  className: PropTypes.string
+  className: PropTypes.string,
+  onlyStates: PropTypes.bool
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,9 +1,8 @@
 import React from 'react' // needed to get JSX in scope for text2paraJsx
 import Config from '../config'
 
-export { getStateFullName } from './state-abbrev'
+export { getStateFullName, getRegions, armedForcesRegions } from './state-abbrev'
 export { countries } from './countries'
-export { states, armedForcesRegions } from './state-abbrev'
 
 export const formatDate = (date) => {
   const monthAbbr = [

--- a/src/lib/state-abbrev.js
+++ b/src/lib/state-abbrev.js
@@ -1,18 +1,14 @@
 export const states = {
   AL: 'Alabama',
   AK: 'Alaska',
-  AS: 'American Samoa',
   AZ: 'Arizona',
   AR: 'Arkansas',
   CA: 'California',
   CO: 'Colorado',
   CT: 'Connecticut',
   DE: 'Delaware',
-  DC: 'District Of Columbia',
-  FM: 'Federated States Of Micronesia',
   FL: 'Florida',
   GA: 'Georgia',
-  GU: 'Guam',
   HI: 'Hawaii',
   ID: 'Idaho',
   IL: 'Illinois',
@@ -22,7 +18,6 @@ export const states = {
   KY: 'Kentucky',
   LA: 'Louisiana',
   ME: 'Maine',
-  MH: 'Marshall Islands',
   MD: 'Maryland',
   MA: 'Massachusetts',
   MI: 'Michigan',
@@ -38,13 +33,10 @@ export const states = {
   NY: 'New York',
   NC: 'North Carolina',
   ND: 'North Dakota',
-  MP: 'Northern Mariana Islands',
   OH: 'Ohio',
   OK: 'Oklahoma',
   OR: 'Oregon',
-  PW: 'Palau',
   PA: 'Pennsylvania',
-  PR: 'Puerto Rico',
   RI: 'Rhode Island',
   SC: 'South Carolina',
   SD: 'South Dakota',
@@ -52,12 +44,23 @@ export const states = {
   TX: 'Texas',
   UT: 'Utah',
   VT: 'Vermont',
-  VI: 'Virgin Islands',
   VA: 'Virginia',
   WA: 'Washington',
   WV: 'West Virginia',
   WI: 'Wisconsin',
   WY: 'Wyoming'
+}
+
+export const miscRegions = {
+  AS: 'American Samoa',
+  DC: 'District Of Columbia',
+  FM: 'Federated States Of Micronesia',
+  GU: 'Guam',
+  MH: 'Marshall Islands',
+  MP: 'Northern Mariana Islands',
+  PW: 'Palau',
+  PR: 'Puerto Rico',
+  VI: 'Virgin Islands'
 }
 
 export const armedForcesRegions = [
@@ -70,5 +73,32 @@ export const armedForcesRegions = [
 ]
 
 export function getStateFullName(stateAbrv) {
-  return states[stateAbrv]
+  return states[stateAbrv] || miscRegions[stateAbrv]
+}
+
+function getRegionsUncached(onlyStates) {
+  const statesArr = Object.keys(states).map(key => [key, states[key]])
+  if (onlyStates) return statesArr
+
+  return [
+    ...statesArr,
+    ...Object.keys(miscRegions).map(key => [key, miscRegions[key]])
+  ].sort((a, b) => a[1].localeCompare(b[1]))
+}
+
+// We'll cache the result in memory
+let ALL_REGIONS = null
+let STATES = null
+
+/**
+ * Gets an array of regions or states. Uses an array because the list is alphabetized
+ * @param {boolean} onlyStates - If true, returns the 50 US states, otherwise also returns territories, etc.
+ * @return {array} An array of arrays, element[i][0] is abbreviation, element[i][1] is full name
+ */
+export function getRegions(onlyStates) {
+  if (onlyStates) {
+    return STATES || (STATES = getRegionsUncached(true))
+  }
+
+  return ALL_REGIONS || (ALL_REGIONS = getRegionsUncached(false))
 }


### PR DESCRIPTION
Gives the bool param `onlyStates` to StateSelect.

So you can only target the elected officials of the 50 states, matching legacy.

We also use StateSelect for search and signing, to which we don't pass `onlyStates`, so it has other regions, matching legacy.