### PR TITLE
add nyc and test:coverage, remove (unused?) test1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/MoveOnOrg/mop-frontend",
   "directories": {},
   "scripts": {
-    "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test test/*",
+    "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js --recursive",
     "test:coverage": "nyc npm test",
     "build": "THEME=legacy webpack && THEME=giraffe webpack",
     "dev-build": "THEME=legacy webpack -d && THEME=giraffe webpack -d",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
   "directories": {},
   "scripts": {
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test test/*",
-    "test1": "NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js test ",
+    "test:coverage": "nyc npm test",
     "build": "THEME=legacy webpack && THEME=giraffe webpack",
     "dev-build": "THEME=legacy webpack -d && THEME=giraffe webpack -d",
     "webpack-watch": "webpack -w",
     "dev": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --hot --progress --colors --port ${PORT:-8080} --inline",
     "lint": "eslint src test .*.js --ignore-pattern='!.eslintrc.js' ",
     "lint-and-test": "npm run lint && npm test"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.js"
+    ]
   },
   "author": "",
   "license": "MIT",
@@ -58,6 +63,7 @@
     "mocha": "^5.0.0",
     "mocha-each": "^1.1.0",
     "nock": "^9.0.13",
+    "nyc": "^11.6.0",
     "react-addons-test-utils": "^15.4.2",
     "react-sparklines": "^1.7.0",
     "react-test-renderer": "^15.5.4",


### PR DESCRIPTION
This gives us a command to check test coverage, as a step toward improving coverage. It also removes the test1 script. Looking at the commit history, I'm not clear why test1 was originally added, so using this PR to at least clarify that, if not remove it.