### PR TITLE
Make sure ThanksNextPetition interval is set on focus

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -399,5 +399,6 @@ export const actions = {
   registerSignatureAndThanks,
   recordShareClick,
   loadPetitionSignatures,
-  getSharebanditShareLink
+  getSharebanditShareLink,
+  loadTopPetitions
 }

--- a/src/components/theme-legacy/thanks.js
+++ b/src/components/theme-legacy/thanks.js
@@ -4,17 +4,17 @@ import PropTypes from 'prop-types'
 import ThanksNextPetition from '../../containers/thanks-next-petition'
 
 const Thanks = ({
-  petition,
   sharedSocially,
   isCreator,
   renderTwitter,
   renderFacebook,
   renderMail,
-  renderCopyPaste
+  renderCopyPaste,
+  nextPetition
 }) => (
   <div className='row'>
     {sharedSocially ? (
-      <ThanksNextPetition entity={petition.entity || ''} />
+      <ThanksNextPetition nextPetition={nextPetition} />
     ) : null}
     <div className='span4'>
       <h1 className='size-superxl lh-100 font-lighter'>Thanks!</h1>
@@ -56,7 +56,6 @@ const Thanks = ({
 )
 
 Thanks.propTypes = {
-  petition: PropTypes.object,
   sharedSocially: PropTypes.bool,
   isCreator: PropTypes.bool,
   shareLink: PropTypes.func,
@@ -67,7 +66,8 @@ Thanks.propTypes = {
   renderFacebook: PropTypes.func,
   renderMail: PropTypes.func,
   renderCopyPaste: PropTypes.func,
-  renderRawLink: PropTypes.func
+  renderRawLink: PropTypes.func,
+  nextPetition: PropTypes.object
 }
 
 export default Thanks

--- a/src/containers/thanks-next-petition.js
+++ b/src/containers/thanks-next-petition.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import { Portal } from 'react-portal'
 
-import { loadTopPetitions } from '../actions/petitionActions'
 import { appLocation } from '../routes.js'
 
 /* A nice description of how/when this works from the Platform Team:
@@ -29,9 +27,6 @@ class ThanksNextPetition extends React.Component {
   }
 
   componentWillMount() {
-    if (!this.props.nextPetitionsLoaded) {
-      this.props.dispatch(loadTopPetitions(this.props.entity === 'pac' ? 1 : 0, '', false))
-    }
     // Start countdown on refocusing to this window
     window.addEventListener('focus', this.startCountdown)
   }
@@ -99,19 +94,7 @@ class ThanksNextPetition extends React.Component {
 }
 
 ThanksNextPetition.propTypes = {
-  dispatch: PropTypes.func,
-  nextPetition: PropTypes.object,
-  nextPetitionsLoaded: PropTypes.bool,
-  entity: PropTypes.string
+  nextPetition: PropTypes.object
 }
 
-function mapStateToProps(store) {
-  const { nextPetitionsLoaded, nextPetitions, petitions } = store.petitionStore
-  let nextPetition = null
-  if (nextPetitions && nextPetitions.length && nextPetitions[0]) {
-    nextPetition = petitions[nextPetitions[0]]
-  }
-  return { nextPetition, nextPetitionsLoaded }
-}
-
-export default connect(mapStateToProps)(ThanksNextPetition)
+export default ThanksNextPetition

--- a/src/containers/thanks-next-petition.js
+++ b/src/containers/thanks-next-petition.js
@@ -39,7 +39,7 @@ class ThanksNextPetition extends React.Component {
   startCountdown() {
     window.removeEventListener('focus', this.startCountdown)
     // Guard against running twice -- countdown should be a singleton
-    if (this.props.nextPetition && this.state.secondsLeft > this.startSeconds) {
+    if (this.state.secondsLeft > this.startSeconds) {
       if (this.state.intervalListener) {
         clearInterval(this.state.intervalListener)
       }

--- a/src/containers/thanks.js
+++ b/src/containers/thanks.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import { actions as petitionActions } from '../actions/petitionActions'
 import { md5ToToken, stringifyParams } from '../lib'
 
@@ -60,6 +61,12 @@ class Thanks extends React.Component {
     this.renderMail = this.renderMail.bind(this)
     this.renderCopyPaste = this.renderCopyPaste.bind(this)
     this.renderRawLink = this.renderRawLink.bind(this)
+  }
+
+  componentDidMount() {
+    if (!this.props.nextPetitionsLoaded) {
+      this.props.dispatch(petitionActions.loadTopPetitions(this.props.petition.entity === 'pac' ? 1 : 0, '', false))
+    }
   }
 
   recordShare(medium, source) {
@@ -133,7 +140,6 @@ class Thanks extends React.Component {
   render() {
     return (
       <ThanksComponent
-        petition={this.props.petition}
         sharedSocially={this.state.sharedSocially}
         isCreator={this.isCreator}
         renderTwitter={this.renderTwitter}
@@ -141,6 +147,7 @@ class Thanks extends React.Component {
         renderMail={this.renderMail}
         renderCopyPaste={this.renderCopyPaste}
         renderRawLink={this.renderRawLink}
+        nextPetition={this.props.nextPetition}
       />
     )
   }
@@ -150,7 +157,19 @@ Thanks.propTypes = {
   petition: PropTypes.object,
   user: PropTypes.object,
   signatureMessage: PropTypes.object,
-  fromSource: PropTypes.string
+  fromSource: PropTypes.string,
+  nextPetitionsLoaded: PropTypes.bool,
+  nextPetition: PropTypes.object,
+  dispatch: PropTypes.func
 }
 
-export default Thanks
+function mapStateToProps(store) {
+  const { nextPetitionsLoaded, nextPetitions, petitions } = store.petitionStore
+  let nextPetition = null
+  if (nextPetitions && nextPetitions.length && nextPetitions[0]) {
+    nextPetition = petitions[nextPetitions[0]]
+  }
+  return { nextPetition, nextPetitionsLoaded }
+}
+
+export default connect(mapStateToProps)(Thanks)

--- a/test/components/thanks.js
+++ b/test/components/thanks.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { expect } from 'chai'
+import { createMockStore } from 'redux-test-utils'
 
 import { mount } from 'enzyme'
 
@@ -8,8 +9,9 @@ import Thanks from '../../src/containers/thanks'
 import outkastPetition from '../../local/api/v1/petitions/outkast.json'
 
 describe('<Thanks />', () => {
+  const store = createMockStore({ petitionStore: {} })
   it('renders thanks for petition', () => {
-    const context = mount(<Thanks petition={outkastPetition} />)
+    const context = mount(<Thanks store={store} petition={outkastPetition} />)
     // console.log(context.html())
     expect(context.find('h1').text()).to.equal('Thanks!')
   })


### PR DESCRIPTION
If nextPetition (from a top-petitions request) was not loaded when the window focused after sharing (probably because of a slow request), the countdown would not start.

This changes it to start the background interval regardless of the top-petitions request. However, if there is some error with that request, the message still won't be shown (guarded in the render method) and they won't be redirected when the interval finishes (guarded in `redirectToNext()`)

Fixes #359