### PR TITLE
Pass page load time (in ms) along with signature request

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -1,6 +1,7 @@
 import 'whatwg-fetch'
 
 import Config from '../config.js'
+import { getPageLoadTime } from '../lib'
 import { appLocation } from '../routes.js'
 
 export const actionTypes = {
@@ -224,6 +225,11 @@ export function signPetition(petitionSignature, petition, options) {
       const signingEndpoint = ((Config.API_SIGN_PETITION)
                                ? Config.API_SIGN_PETITION
                                : `${Config.API_URI}/signatures.json`)
+      const body = petitionSignature
+      const pageLoadTime = getPageLoadTime()
+      if (pageLoadTime) {
+        body.loadTime = pageLoadTime
+      }
       const fetchArgs = {
         method: 'POST',
         body: JSON.stringify(petitionSignature),

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -113,3 +113,19 @@ export const stringifyParams = obj =>
   Object.keys(obj)
     .map(key => `${key}=${encodeURIComponent(obj[key])}`)
     .join('&')
+
+export const getPageLoadTime = () => {
+  if (
+    window &&
+    window.performance &&
+    window.performance.timing &&
+    window.performance.timing.loadEventEnd &&
+    window.performance.timing.fetchStart
+  ) {
+    return (
+      window.performance.timing.loadEventEnd -
+      window.performance.timing.fetchStart
+    )
+  }
+  return null
+}


### PR DESCRIPTION
Fixes #363 (in terms of loading)

It seems this load event fires when all page dependencies have been loaded, so it won't count things like JS parsing and rendering.

For that it seems we would have to set a variable to Date.now() when the page first renders, which could go along with #348, as there is nothing useful listed on https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming

Let me know if you want me to include rendering or if this is good enough for now.
