### PR TITLE
Move loadSession to wrapper so it only fires once

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -54,8 +54,8 @@ function callSessionApi(tokens) {
   }
 }
 
-export const loadSession = ({ location }) => {
-  // Called straigt from top route onEnter, so it's done only once on first-load
+export const loadSession = (location) => {
+  // Called from Wrapper container, so it's done only once on first-load
 
   // A cookie doesn't actually indicate authenticated -- we just mark the session differently
   const cookie = String(document.cookie).match(new RegExp(`${Config.SESSION_COOKIE_NAME}=([^;]+)`))

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -2,29 +2,32 @@ import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
+import { loadSession } from '../actions/sessionActions'
+
 import WrapperComponent from 'Theme/wrapper'
 
-export const Wrapper = ({
-  petitionEntity,
-  location,
-  children,
-  params,
-  routes
-}) => {
-  let entity = petitionEntity
-  if (location.pathname.indexOf('/pac/') !== -1) {
-    entity = 'pac'
+class Wrapper extends React.Component {
+  componentDidMount() {
+    this.props.dispatch(loadSession(this.props.location))
   }
 
-  return (
-    <WrapperComponent
-      entity={entity}
-      organization={(params && params.organization) || ''}
-      minimalNav={!!routes[routes.length - 1].minimalNav}
-    >
-      {children}
-    </WrapperComponent>
-  )
+  render() {
+    const { petitionEntity, location, children, params, routes } = this.props
+    let entity = petitionEntity
+    if (location.pathname.indexOf('/pac/') !== -1) {
+      entity = 'pac'
+    }
+
+    return (
+      <WrapperComponent
+        entity={entity}
+        organization={(params && params.organization) || ''}
+        minimalNav={!!routes[routes.length - 1].minimalNav}
+      >
+        {children}
+      </WrapperComponent>
+    )
+  }
 }
 
 Wrapper.propTypes = {
@@ -32,7 +35,8 @@ Wrapper.propTypes = {
   location: PropTypes.object,
   children: PropTypes.object.isRequired,
   params: PropTypes.object,
-  routes: PropTypes.array.isRequired
+  routes: PropTypes.array.isRequired,
+  dispatch: PropTypes.func.isRequired
 }
 
 function mapStateToProps(store, ownProps) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import { IndexRoute, Route, Router, browserHistory, hashHistory, match } from 'r
 
 
 import { Config } from './config'
-import { loadSession, trackPage } from './actions/sessionActions'
+import { trackPage } from './actions/sessionActions'
 import { loadOrganization } from './actions/navActions.js'
 import Home from './containers/home'
 import PacHome from './containers/pac-home'
@@ -75,7 +75,7 @@ export const routes = (store) => {
     }
   }
   const routeHierarchy = (
-    <Route path={baseAppPath} component={Wrapper} onEnter={(nextState) => { store.dispatch(loadSession(nextState)) }} >
+    <Route path={baseAppPath} component={Wrapper}>
       <IndexRoute prodReady component={Home} />
       <Route path='pac/' component={PacHome} />
       <Route path='sign/:petition_slug' component={SignPetition} />


### PR DESCRIPTION
First I tried refactoring routes() to a class, but it didn't work out since the current location wasn't available outside <Router> 🚯 

This should still be fairly discoverable, with the comment in loadSession

fixes #348 