### PR TITLE
Pass thirdPartyOptin correctly to sign form, handle toggling correctly

### DIFF
--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -144,7 +144,7 @@ const SignatureAddForm = ({
         name='thirdparty_optin'
         type='checkbox'
         label={`Receive campaign updates from ${creator.organization || 'this organization'}`}
-        onChange={updateStateFromValue('thirdparty_optin', true)}
+        onChange={updateStateFromValue('thirdparty_optin', /* isCheckbox: */true)}
         defaultChecked={thirdPartyOptin}
       />
     )}

--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -16,6 +16,7 @@ const SignatureAddForm = ({
   onChangeCountry,
   showOptinWarning,
   showOptinCheckbox,
+  thirdPartyOptin,
   showAddressFields,
   requireAddressFields,
   onUnrecognize,
@@ -144,6 +145,7 @@ const SignatureAddForm = ({
         type='checkbox'
         label={`Receive campaign updates from ${creator.organization || 'this organization'}`}
         onChange={updateStateFromValue('thirdparty_optin')}
+        defaultChecked={thirdPartyOptin}
       />
     )}
 
@@ -179,6 +181,7 @@ SignatureAddForm.propTypes = {
   onUnrecognize: PropTypes.func,
   showOptinWarning: PropTypes.bool,
   showOptinCheckbox: PropTypes.bool,
+  thirdPartyOptin: PropTypes.bool,
   hiddenOptin: PropTypes.bool,
   volunteer: PropTypes.bool,
   onClickVolunteer: PropTypes.func,

--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -144,7 +144,7 @@ const SignatureAddForm = ({
         name='thirdparty_optin'
         type='checkbox'
         label={`Receive campaign updates from ${creator.organization || 'this organization'}`}
-        onChange={updateStateFromValue('thirdparty_optin')}
+        onChange={updateStateFromValue('thirdparty_optin', true)}
         defaultChecked={thirdPartyOptin}
       />
     )}

--- a/src/components/theme-legacy/signature-add-form.js
+++ b/src/components/theme-legacy/signature-add-form.js
@@ -267,7 +267,7 @@ const SignatureAddForm = ({
                 id='thirdparty_optin'
                 name='thirdparty_optin'
                 className='moveon-track-click'
-                onChange={updateStateFromValue('thirdparty_optin', true)}
+                onChange={updateStateFromValue('thirdparty_optin', /* isCheckbox: */true)}
                 defaultChecked={thirdPartyOptin}
               />{' '}
               Receive campaign updates from{' '}

--- a/src/components/theme-legacy/signature-add-form.js
+++ b/src/components/theme-legacy/signature-add-form.js
@@ -19,6 +19,7 @@ const SignatureAddForm = ({
   onChangeCountry,
   showOptinWarning,
   showOptinCheckbox,
+  thirdPartyOptin,
   hiddenOptin,
   showAddressFields,
   requireAddressFields,
@@ -267,6 +268,7 @@ const SignatureAddForm = ({
                 name='thirdparty_optin'
                 className='moveon-track-click'
                 onChange={updateStateFromValue('thirdparty_optin')}
+                defaultChecked={thirdPartyOptin}
               />{' '}
               Receive campaign updates from{' '}
               {creator.organization || 'this organization'}.
@@ -323,6 +325,7 @@ SignatureAddForm.propTypes = {
   onUnrecognize: PropTypes.func,
   showOptinWarning: PropTypes.bool,
   showOptinCheckbox: PropTypes.bool,
+  thirdPartyOptin: PropTypes.bool,
   hiddenOptin: PropTypes.bool,
   volunteer: PropTypes.bool,
   onClickVolunteer: PropTypes.func,

--- a/src/components/theme-legacy/signature-add-form.js
+++ b/src/components/theme-legacy/signature-add-form.js
@@ -267,7 +267,7 @@ const SignatureAddForm = ({
                 id='thirdparty_optin'
                 name='thirdparty_optin'
                 className='moveon-track-click'
-                onChange={updateStateFromValue('thirdparty_optin')}
+                onChange={updateStateFromValue('thirdparty_optin', true)}
                 defaultChecked={thirdPartyOptin}
               />{' '}
               Receive campaign updates from{' '}

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -220,7 +220,7 @@ class SignatureAddForm extends React.Component {
         onUnrecognize={() => { dispatch(sessionActions.unRecognize()) }}
         volunteer={this.state.volunteer}
         onClickVolunteer={this.volunteer}
-
+        thirdPartyOptin={this.state.thirdparty_optin}
         country={this.state.country}
         onChangeCountry={event => this.setState({ country: event.target.value })}
         updateStateFromValue={this.updateStateFromValue}

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -131,9 +131,10 @@ class SignatureAddForm extends React.Component {
     ).reduce((a, b) => a && b, true)
   }
 
-  updateStateFromValue(field) {
+  updateStateFromValue(field, isCheckbox = false) {
     return (event) => {
-      this.setState({ [field]: event.target.value })
+      const value = isCheckbox ? event.target.checked : event.target.value
+      this.setState({ [field]: value })
     }
   }
 

--- a/src/giraffe-ui/petition/input-block.js
+++ b/src/giraffe-ui/petition/input-block.js
@@ -9,7 +9,8 @@ export const InputBlock = ({
   onChange,
   type,
   className,
-  setRef
+  setRef,
+  ...rest
 }) => (
   <div
     className={cx(
@@ -25,6 +26,7 @@ export const InputBlock = ({
         onChange={onChange}
         onBlur={onChange}
         ref={setRef}
+        {...rest}
       />
     )}
     <label htmlFor={name}>{label}</label>


### PR DESCRIPTION
Previously, we weren't passing the value in the state to be set as the checkbox's default value.

Additionally, toggling of the checkbox wasn't updating the state correctly.