### PR TITLE
Add margin to giraffe static pages

### DIFF
--- a/src/components/theme-giraffe/static.js
+++ b/src/components/theme-giraffe/static.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Static = ({ children }) => (
+  <div className='container'>
+    <div className='row justify-content-center my-4 my-md-5'>
+      <div className='col-12 col-md-10'>{children}</div>
+    </div>
+  </div>
+)
+
+Static.propTypes = { children: PropTypes.node }
+
+export default Static

--- a/src/containers/static.js
+++ b/src/containers/static.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { loadStaticPage } from '../actions/staticPageActions'
 
-import StaticComponent from 'LegacyTheme/static'
+import StaticComponent from 'Theme/static'
 
 const getId = routes => routes && routes[routes.length - 1].wordpressId
 


### PR DESCRIPTION
Gives 10 columns to content on desktop. Full width on mobile.

Fixes #329 