### PR TITLE
Logout

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -1,6 +1,7 @@
 import 'whatwg-fetch'
 
 import Config from '../config.js'
+import { appLocation } from '../routes'
 
 export const actionTypes = {
   ANONYMOUS_SESSION_START: 'ANONYMOUS_SESSION_START',
@@ -9,10 +10,17 @@ export const actionTypes = {
   USER_SESSION_FAILURE: 'USER_SESSION_FAILURE'
 }
 
-export function unRecognize() {
+export function unRecognize({ redirect } = {}) {
   return (dispatch) => {
-    dispatch({
-      type: actionTypes.UNRECOGNIZE_USER_SESSION
+    fetch(`${Config.API_URI}/user/session/logout`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    .then(() => {
+      dispatch({
+        type: actionTypes.UNRECOGNIZE_USER_SESSION
+      })
+      if (redirect) appLocation.push(redirect)
     })
   }
 }

--- a/src/components/theme-legacy/nav-link.js
+++ b/src/components/theme-legacy/nav-link.js
@@ -2,13 +2,18 @@ import React from 'react'
 import { Link } from 'react-router'
 import PropTypes from 'prop-types'
 
-const NavLink = ({ to, children }) => (
-  <li><Link className='lh-14 navlink' to={to}>{children}</Link></li>
+const NavLink = ({ to, children, onClick }) => (
+  <li>
+    <Link className='lh-14 navlink' to={to} onClick={onClick}>
+      {children}
+    </Link>
+  </li>
 )
 
 NavLink.propTypes = {
   to: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+  onClick: PropTypes.func,
+  children: PropTypes.node
 }
 
 export default NavLink

--- a/src/components/theme-legacy/nav.js
+++ b/src/components/theme-legacy/nav.js
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import NavLink from 'LegacyTheme/nav-link'
 
-const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entity }) => {
+const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entity, onLogout }) => {
   const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
 
   const ulClassNames = classNames({
@@ -19,7 +19,7 @@ const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entit
         <NavLink to='/admin'>Admin</NavLink>
         <NavLink to='/campaign_tips.html'>Campaign Tips</NavLink>
         <NavLink to='/edit_account.html'>Edit account</NavLink>
-        <NavLink to='/login/do_logout.html?redirect=/index.html'>Logout</NavLink>
+        <NavLink onClick={onLogout}>Logout</NavLink>
         <NavLink to='https://civic.moveon.org/donatec4/creditcard.html?cpn_id=511'>Donate</NavLink>
       </ul>
     </div>
@@ -113,7 +113,8 @@ Nav.propTypes = {
   minimal: PropTypes.bool,
   toggleOpen: PropTypes.func,
   isOpenMobile: PropTypes.bool,
-  entity: PropTypes.string
+  entity: PropTypes.string,
+  onLogout: PropTypes.func
 }
 
 export default Nav

--- a/src/containers/nav.js
+++ b/src/containers/nav.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import NavComponent from 'Theme/nav'
 
+import { actions as sessionActions } from '../actions/sessionActions.js'
+
 class Nav extends React.Component {
   constructor() {
     super()
@@ -36,7 +38,7 @@ class Nav extends React.Component {
   }
 
   render() {
-    const { user, nav, organization, minimal, entity } = this.props
+    const { user, nav, organization, minimal, entity, dispatch } = this.props
     return (
       <NavComponent
         user={user}
@@ -49,6 +51,7 @@ class Nav extends React.Component {
         isOpenMobile={this.state.isOpenMobile}
         toggleSection={this.toggleSection}
         openSections={this.state.openSections}
+        onLogout={() => dispatch(sessionActions.unRecognize({ redirect: '/' }))}
       />
     )
   }
@@ -59,7 +62,8 @@ Nav.propTypes = {
   nav: PropTypes.object,
   organization: PropTypes.string,
   minimal: PropTypes.bool,
-  entity: PropTypes.string
+  entity: PropTypes.string,
+  dispatch: PropTypes.func
 }
 
 function mapStateToProps(store) {


### PR DESCRIPTION
Adds to #409 

This updates the logout link in the nav (redirects to '/', as well as the logout link when signing a petition (doesn't redirect)

I believe that if this is deployed to prod, we need to make sure that the logout api is working there, since the logout link is displayed on prodReady pages, if user is logged in.