### PR TITLE
Fix segment tracking to override canonical url

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -92,7 +92,7 @@ export const trackPage = () => {
       window.analytics.page({
         // overrides any canonical url set
         location: href,
-        page: pathname,
+        path: pathname,
         url: href
       })
     } else if (window.gtag) {


### PR DESCRIPTION
We were using `page` before, which is wrong.
See https://github.com/segmentio/analytics.js/blob/b237600d802e8d1afda7e7a27baec5998fc05471/analytics.js#L6499

Fixes #411 
Also in mop https://github.com/MoveOnOrg/mop/pull/333