### PR TITLE
Fix partner logos

### DIFF
--- a/src/components/theme-legacy/nav.js
+++ b/src/components/theme-legacy/nav.js
@@ -4,10 +4,9 @@ import { Link } from 'react-router'
 import classNames from 'classnames'
 
 import NavLink from 'LegacyTheme/nav-link'
+import CobrandLogo from '../../containers/cobrand-logo'
 
-const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entity }) => {
-  const cobrand = ((organization) ? nav.orgs[organization] : nav.partnerCobrand)
-
+const Nav = ({ user, minimal, toggleOpen, isOpenMobile, entity }) => {
   const ulClassNames = classNames({
     nav: true,
     'collapse nav-collapse': !isOpenMobile
@@ -43,11 +42,6 @@ const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entit
     <Link className='icon-link-narrow icon-managepetitions' to='/dashboard.html?source=topnav'>Manage Petitions</Link>
   )
 
-  const partnerLogoLinks = (
-    (cobrand)
-      ? (<Link to={cobrand.browser_url}><img className='org_logo' src={cobrand.logo_image_url} alt={`${cobrand.organization} logo`} /></Link>
-        ) : null)
-
   return (
     <div>
       <div className='container' id='header'>
@@ -67,7 +61,7 @@ const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entit
             <div>
               <div className='pull-left top-icons hidden-phone'>
                 <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2 hidden-phone'>
-                 {partnerLogoLinks}
+                  <CobrandLogo />
                 </div>
                 <Link className='icon-link-narrow icon-start' to='/create_start.html?source=topnav'>Start a petition</Link>
                 {user.given_name ? userDashboardLink : guestDashboardLink}
@@ -98,7 +92,7 @@ const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entit
       <div className='container visible-phone'>
         <div className='row pull-left'>
           <div className='pull-left span2 petitions-partner-logo bump-top-1 margin-right-2'>
-            {partnerLogoLinks}
+            <CobrandLogo />
           </div>
         </div>
       </div>
@@ -108,8 +102,7 @@ const Nav = ({ user, nav, organization, minimal, toggleOpen, isOpenMobile, entit
 
 Nav.propTypes = {
   user: PropTypes.object,
-  nav: PropTypes.object,
-  organization: PropTypes.string,
+  cobrand: PropTypes.object,
   minimal: PropTypes.bool,
   toggleOpen: PropTypes.func,
   isOpenMobile: PropTypes.bool,

--- a/src/components/theme-legacy/wrapper.js
+++ b/src/components/theme-legacy/wrapper.js
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types'
 import Nav from '../../containers/nav'
 import Footer from 'LegacyTheme/footer'
 
-const Wrapper = ({ children, organization, minimalNav, entity }) => (
+const Wrapper = ({ children, minimalNav, entity }) => (
   <div className='moveon-petitions'>
     <div id='message-portal'>
       {/* This div will be used to render petition message (currently the share redirect) in theme-legacy */}
     </div>
-    <Nav organization={organization} minimal={minimalNav} entity={entity} />
+    <Nav minimal={minimalNav} entity={entity} />
     <main className='main'>{children}</main>
     <hr />
     <Footer entity={entity} />
@@ -19,7 +19,6 @@ const Wrapper = ({ children, organization, minimalNav, entity }) => (
 
 Wrapper.propTypes = {
   children: PropTypes.object.isRequired,
-  organization: PropTypes.string,
   minimalNav: PropTypes.bool,
   entity: PropTypes.string
 }

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -45,7 +45,7 @@ const getCobrandFromPetition = (petition = {}) => {
 }
 
 const mapStateToProps = ({ navStore, petitionStore }, { params }) => {
-  let cobrand = {}
+  let cobrand
 
   // Will be present we are at an org url
   const orgName = params && params.organization

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -17,8 +17,9 @@ class CobrandLogo extends React.Component {
   }
 
   render() {
-    const { cobrand } = this.props
-    if (!cobrand) return null
+    const { cobrand, shouldLink } = this.props
+    // Don’t render if org has no logo
+    if (!cobrand || !cobrand.logo_image_url) return null
 
     if (cobrand.browser_url) {
       return <Link to={cobrand.browser_url}>{this.renderLogo()}</Link>
@@ -35,7 +36,6 @@ const getCobrandFromPetition = (petition = {}) => {
   if (!branding) return null
 
   const { organization_logo_image_url, organization, browser_url } = branding
-  if (!organization_logo_image_url) return null
 
   return {
     logo_image_url: organization_logo_image_url, // format of the org api

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -17,11 +17,12 @@ class CobrandLogo extends React.Component {
   }
 
   render() {
-    const { cobrand, shouldLink } = this.props
+    const { cobrand, link } = this.props
     // Don’t render if org has no logo
     if (!cobrand || !cobrand.logo_image_url) return null
 
-    if (cobrand.browser_url) {
+    // `props.link` (defaults to false) will give the logo a link to the partner’s homepage, if defined
+    if (cobrand.browser_url && link) {
       return <Link to={cobrand.browser_url}>{this.renderLogo()}</Link>
     }
 
@@ -47,7 +48,7 @@ const getCobrandFromPetition = (petition = {}) => {
 const mapStateToProps = ({ navStore, petitionStore }, { params }) => {
   let cobrand
 
-  // Will be present we are at an org url
+  // Will be present we are at an org url (mega-partner)
   const orgName = params && params.organization
 
   // Will be present if we are viewing a petition
@@ -58,14 +59,15 @@ const mapStateToProps = ({ navStore, petitionStore }, { params }) => {
     // check the url for an organization
     cobrand = navStore.orgs[orgName]
   } else if (petition) {
-    // check the currently viewed petition
+    // check the currently viewed petition, for non-megapartner orgs
     cobrand = getCobrandFromPetition(petition)
   }
   return { cobrand }
 }
 
 CobrandLogo.propTypes = {
-  cobrand: PropTypes.object
+  cobrand: PropTypes.object,
+  link: PropTypes.bool
 }
 
 export default withRouter(connect(mapStateToProps)(CobrandLogo))

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react'
-import { Link, withRouter } from 'react-router'
+import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
@@ -17,14 +17,9 @@ class CobrandLogo extends React.Component {
   }
 
   render() {
-    const { cobrand, link } = this.props
+    const { cobrand } = this.props
     // Don’t render if org has no logo
     if (!cobrand || !cobrand.logo_image_url) return null
-
-    // `props.link` (defaults to false) will give the logo a link to the partner’s homepage, if defined
-    if (cobrand.browser_url && link) {
-      return <Link to={cobrand.browser_url}>{this.renderLogo()}</Link>
-    }
 
     return this.renderLogo()
   }
@@ -36,12 +31,11 @@ const getCobrandFromPetition = (petition = {}) => {
   const branding = sponsor || creator
   if (!branding) return null
 
-  const { organization_logo_image_url, organization, browser_url } = branding
+  const { organization_logo_image_url, organization } = branding
 
   return {
     logo_image_url: organization_logo_image_url, // format of the org api
-    organization,
-    browser_url
+    organization
   }
 }
 

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -1,0 +1,71 @@
+/* eslint-disable camelcase */
+import React from 'react'
+import { Link, withRouter } from 'react-router'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+class CobrandLogo extends React.Component {
+  renderLogo() {
+    const { cobrand } = this.props
+    return (
+      <img
+        className='org_logo'
+        src={cobrand.logo_image_url}
+        alt={`${cobrand.organization} logo`}
+      />
+    )
+  }
+
+  render() {
+    const { cobrand } = this.props
+    if (!cobrand) return null
+
+    if (cobrand.browser_url) {
+      return <Link to={cobrand.browser_url}>{this.renderLogo()}</Link>
+    }
+
+    return this.renderLogo()
+  }
+}
+
+const getCobrandFromPetition = (petition = {}) => {
+  // grab the sponsor / creator properties from _embedded if it exists
+  const { _embedded: { sponsor, creator } = {} } = petition
+  const branding = sponsor || creator
+  if (!branding) return null
+
+  const { organization_logo_image_url, organization, browser_url } = branding
+  if (!organization_logo_image_url) return null
+
+  return {
+    logo_image_url: organization_logo_image_url, // format of the org api
+    organization,
+    browser_url
+  }
+}
+
+const mapStateToProps = ({ navStore, petitionStore }, { params }) => {
+  let cobrand = {}
+
+  // Will be present we are at an org url
+  const orgName = params && params.organization
+
+  // Will be present if we are viewing a petition
+  const petitionSlug = params && params.petition_slug
+  const petition = petitionSlug && petitionStore.petitions[petitionSlug]
+
+  if (orgName) {
+    // check the url for an organization
+    cobrand = navStore.orgs[orgName]
+  } else if (petition) {
+    // check the currently viewed petition
+    cobrand = getCobrandFromPetition(petition)
+  }
+  return { cobrand }
+}
+
+CobrandLogo.propTypes = {
+  cobrand: PropTypes.object
+}
+
+export default withRouter(connect(mapStateToProps)(CobrandLogo))

--- a/src/containers/nav.js
+++ b/src/containers/nav.js
@@ -36,12 +36,10 @@ class Nav extends React.Component {
   }
 
   render() {
-    const { user, nav, organization, minimal, entity } = this.props
+    const { user, minimal, entity } = this.props
     return (
       <NavComponent
         user={user}
-        nav={nav}
-        organization={organization}
         minimal={minimal}
         entity={entity}
         close={this.close}
@@ -64,8 +62,7 @@ Nav.propTypes = {
 
 function mapStateToProps(store) {
   return {
-    user: store.userStore,
-    nav: store.navStore
+    user: store.userStore
   }
 }
 

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -12,7 +12,7 @@ class Wrapper extends React.Component {
   }
 
   render() {
-    const { petitionEntity, location, children, params, routes } = this.props
+    const { petitionEntity, location, children, routes } = this.props
     let entity = petitionEntity
     if (location.pathname.indexOf('/pac/') !== -1) {
       entity = 'pac'
@@ -21,7 +21,6 @@ class Wrapper extends React.Component {
     return (
       <WrapperComponent
         entity={entity}
-        organization={(params && params.organization) || ''}
         minimalNav={!!routes[routes.length - 1].minimalNav}
       >
         {children}
@@ -34,7 +33,6 @@ Wrapper.propTypes = {
   petitionEntity: PropTypes.string,
   location: PropTypes.object,
   children: PropTypes.object.isRequired,
-  params: PropTypes.object,
   routes: PropTypes.array.isRequired,
   dispatch: PropTypes.func.isRequired
 }

--- a/src/reducers/nav.js
+++ b/src/reducers/nav.js
@@ -1,44 +1,13 @@
 import { combineReducers } from 'redux'
 import { actionTypes as navActionTypes } from '../actions/navActions.js'
-import { actionTypes as petitionActionTypes } from '../actions/petitionActions.js'
 
-const { FETCH_PETITON_SUCCESS, FETCH_TOP_PETITIONS_SUCCESS } = petitionActionTypes
 const { FETCH_ORG_SUCCESS } = navActionTypes
 
 /* nav state:
  * {
- *   partnerCobrand: null || { logo_image_url, organization, browser_url },
  *   orgs: { [slug]: org }
  * }
  */
-
-const getCobrandFromPetition = (petition = {}) => {
-  // grab the sponsor / creator properties from _embedded if it exists
-  const { _embedded: { sponsor, creator } = {} } = petition
-  const branding = sponsor || creator
-  if (!branding) {
-    return null
-  }
-
-  const { logo_image_url, organization, browser_url } = branding
-  // eslint-disable-next-line camelcase
-  if (!logo_image_url) {
-    return null
-  }
-
-  return { logo_image_url, organization, browser_url }
-}
-
-function partnerCobrand(state = null, action) {
-  switch (action.type) {
-    case FETCH_PETITON_SUCCESS:
-      return getCobrandFromPetition(action.petition)
-    case FETCH_TOP_PETITIONS_SUCCESS:
-      return getCobrandFromPetition(action.petitions[0])
-    default:
-      return state
-  }
-}
 
 function orgs(state = {}, action) {
   switch (action.type) {
@@ -53,7 +22,5 @@ function orgs(state = {}, action) {
 }
 
 export default combineReducers({
-  partnerCobrand,
   orgs
 })
-

--- a/test/components/cobrand-logo.js
+++ b/test/components/cobrand-logo.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router'
 import { expect } from 'chai'
 import { mount } from 'enzyme'
 import { createMockStore } from 'redux-test-utils'
@@ -35,34 +34,31 @@ function getParams({ embed, org }) {
 describe('<CobrandLogo />', () => {
   const brandOnly = {
     organization_logo_image_url: 'yes.jpg',
-    organization: 'Move On',
-    browser_url: 'http://example.com'
+    organization: 'Move On'
   }
   const brandWithFluff = { ...brandOnly, fluff: true }
   const wrongBrand = { ...brandWithFluff, organization: 'not me' }
 
   it('doesn’t render if no org', () => {
     const context = mount(
-      <CobrandLogo link {...getParams({ embed: { creator: { name: 'someone' } } })} />
+      <CobrandLogo {...getParams({ embed: { creator: { name: 'someone' } } })} />
     )
     expect(context.html()).to.equal(null)
   })
 
-  it('sets cobrand using sponsor in loaded petition with link', () => {
+  it('sets cobrand using sponsor in loaded petition', () => {
     const context = mount(
       <CobrandLogo link {...getParams({ embed: { sponsor: brandOnly } })} />
     )
-    expect(context.find(Link).prop('to')).to.equal('http://example.com')
     expect(context.find('img').html()).to.equal(
       '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
     )
   })
 
-  it('sets cobrand using creator in loaded petition without link', () => {
+  it('sets cobrand using creator in loaded petition', () => {
     const context = mount(
       <CobrandLogo {...getParams({ embed: { creator: brandOnly } })} />
     )
-    expect(context.find(Link).length).to.equal(0)
     expect(context.find('img').html()).to.equal(
       '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
     )
@@ -84,8 +80,7 @@ describe('<CobrandLogo />', () => {
   it('sets cobrand using orgStore, overriding loaded petition', () => {
     const urlOrg = {
       logo_image_url: 'org.jpg',
-      organization: 'Another org',
-      browser_url: 'http://example2.com'
+      organization: 'Another org'
     }
     const context = mount(
       <CobrandLogo

--- a/test/components/cobrand-logo.js
+++ b/test/components/cobrand-logo.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import { Link } from 'react-router'
+import { expect } from 'chai'
+import { mount } from 'enzyme'
+import { createMockStore } from 'redux-test-utils'
+
+import CobrandLogo from '../../src/containers/cobrand-logo'
+
+function getParams({ embed, org }) {
+  const petitionSlug = 'test'
+  const orgSlug = 'test-org'
+  const store = {}
+  const params = {}
+  if (embed) {
+    store.petitionStore = {
+      petitions: { [petitionSlug]: { _embedded: embed } }
+    }
+
+    params.petition_slug = petitionSlug
+  }
+
+  if (org) {
+    store.navStore = {
+      orgs: { [orgSlug]: org }
+    }
+    params.organization = orgSlug
+  }
+
+  return {
+    params,
+    store: createMockStore(store)
+  }
+}
+
+describe('<CobrandLogo />', () => {
+  const brandOnly = {
+    organization_logo_image_url: 'yes.jpg',
+    organization: 'Move On',
+    browser_url: 'http://example.com'
+  }
+  const brandWithFluff = { ...brandOnly, fluff: true }
+  const wrongBrand = { ...brandWithFluff, organization: 'not me' }
+
+  it('sets cobrand using sponsor in loaded petition', () => {
+    const context = mount(
+      <CobrandLogo {...getParams({ embed: { sponsor: brandOnly } })} />
+    )
+    expect(context.find(Link).prop('to')).to.equal('http://example.com')
+    expect(context.find('img').html()).to.equal(
+      '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
+    )
+  })
+
+  it('sets cobrand using creator in loaded petition', () => {
+    const context = mount(
+      <CobrandLogo {...getParams({ embed: { creator: brandOnly } })} />
+    )
+    expect(context.find(Link).prop('to')).to.equal('http://example.com')
+    expect(context.find('img').html()).to.equal(
+      '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
+    )
+  })
+
+  it('sets cobrand using sponsor when both sponsor and creator in loaded petition', () => {
+    const context = mount(
+      <CobrandLogo
+        {...getParams({
+          embed: { sponsor: brandWithFluff, creator: wrongBrand }
+        })}
+      />
+    )
+    expect(context.find(Link).prop('to')).to.equal('http://example.com')
+    expect(context.find('img').html()).to.equal(
+      '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
+    )
+  })
+
+  it('sets cobrand using an org url, overriding loaded petition', () => {
+    const urlOrg = {
+      logo_image_url: 'org.jpg',
+      organization: 'Another org',
+      browser_url: 'http://example2.com'
+    }
+    const context = mount(
+      <CobrandLogo
+        {...getParams({ embed: { creator: brandOnly }, org: urlOrg })}
+      />
+    )
+    expect(context.find(Link).prop('to')).to.equal('http://example2.com')
+    expect(context.find('img').html()).to.equal(
+      '<img class="org_logo" src="org.jpg" alt="Another org logo">'
+    )
+  })
+})

--- a/test/components/cobrand-logo.js
+++ b/test/components/cobrand-logo.js
@@ -41,9 +41,16 @@ describe('<CobrandLogo />', () => {
   const brandWithFluff = { ...brandOnly, fluff: true }
   const wrongBrand = { ...brandWithFluff, organization: 'not me' }
 
-  it('sets cobrand using sponsor in loaded petition', () => {
+  it('doesn’t render if no org', () => {
     const context = mount(
-      <CobrandLogo {...getParams({ embed: { sponsor: brandOnly } })} />
+      <CobrandLogo link {...getParams({ embed: { creator: { name: 'someone' } } })} />
+    )
+    expect(context.html()).to.equal(null)
+  })
+
+  it('sets cobrand using sponsor in loaded petition with link', () => {
+    const context = mount(
+      <CobrandLogo link {...getParams({ embed: { sponsor: brandOnly } })} />
     )
     expect(context.find(Link).prop('to')).to.equal('http://example.com')
     expect(context.find('img').html()).to.equal(
@@ -51,11 +58,11 @@ describe('<CobrandLogo />', () => {
     )
   })
 
-  it('sets cobrand using creator in loaded petition', () => {
+  it('sets cobrand using creator in loaded petition without link', () => {
     const context = mount(
       <CobrandLogo {...getParams({ embed: { creator: brandOnly } })} />
     )
-    expect(context.find(Link).prop('to')).to.equal('http://example.com')
+    expect(context.find(Link).length).to.equal(0)
     expect(context.find('img').html()).to.equal(
       '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
     )
@@ -69,13 +76,12 @@ describe('<CobrandLogo />', () => {
         })}
       />
     )
-    expect(context.find(Link).prop('to')).to.equal('http://example.com')
     expect(context.find('img').html()).to.equal(
       '<img class="org_logo" src="yes.jpg" alt="Move On logo">'
     )
   })
 
-  it('sets cobrand using an org url, overriding loaded petition', () => {
+  it('sets cobrand using orgStore, overriding loaded petition', () => {
     const urlOrg = {
       logo_image_url: 'org.jpg',
       organization: 'Another org',
@@ -86,7 +92,6 @@ describe('<CobrandLogo />', () => {
         {...getParams({ embed: { creator: brandOnly }, org: urlOrg })}
       />
     )
-    expect(context.find(Link).prop('to')).to.equal('http://example2.com')
     expect(context.find('img').html()).to.equal(
       '<img class="org_logo" src="org.jpg" alt="Another org logo">'
     )

--- a/test/reducers/nav.js
+++ b/test/reducers/nav.js
@@ -2,9 +2,7 @@ import { expect } from 'chai'
 import reducer from '../../src/reducers/nav'
 
 import { actionTypes as navActionTypes } from '../../src/actions/navActions.js'
-import { actionTypes as petitionActionTypes } from '../../src/actions/petitionActions.js'
 
-const { FETCH_PETITON_SUCCESS, FETCH_TOP_PETITIONS_SUCCESS } = petitionActionTypes
 const { FETCH_ORG_SUCCESS } = navActionTypes
 
 const defaultState = reducer(undefined, {})
@@ -12,8 +10,7 @@ const defaultState = reducer(undefined, {})
 describe('nav reducer', () => {
   it('default state', () => {
     expect(defaultState).to.deep.equal({
-      orgs: {},
-      partnerCobrand: null
+      orgs: {}
     })
   })
 
@@ -41,44 +38,4 @@ describe('nav reducer', () => {
     expect(state.orgs.test2, 'orgs.test2 unchanged')
       .to.equal('test2')
   })
-
-  const brandOnly = { logo_image_url: 'yes.jpg', organization: 'Move On', browser_url: 'http://' }
-  const brandWithFluff = { ...brandOnly, fluff: true }
-  const wrongBrand = { ...brandWithFluff, organization: 'not me' }
-
-  function testPetitionVariants(name, actionCreator) {
-    describe(name, () => {
-      it('sets cobrand using sponsor', () => {
-        const state = reducer(defaultState, actionCreator({ _embedded: { sponsor: brandWithFluff } }))
-        expect(state.partnerCobrand).to.deep.equal(brandOnly)
-      })
-
-      it('sets cobrand using creator', () => {
-        const state = reducer(defaultState, actionCreator({ _embedded: { creator: brandWithFluff } }))
-        expect(state.partnerCobrand).to.deep.equal(brandOnly)
-      })
-
-      it('sets cobrand using sponsor when both sponsor and creator', () => {
-        const state = reducer(defaultState, actionCreator({ _embedded: { sponsor: brandWithFluff, creator: wrongBrand } }))
-        expect(state.partnerCobrand).to.deep.equal(brandOnly)
-      })
-
-      it('sets to null after a new action without sponsor or creator', () => {
-        const filledState = reducer(defaultState, actionCreator({ _embedded: { creator: brandWithFluff } }))
-
-        const state = reducer(filledState, actionCreator({}))
-        expect(state.partnerCobrand).to.deep.equal(null)
-      })
-    })
-  }
-
-  testPetitionVariants('FETCH_PETITION_SUCCESS', petition => ({
-    type: FETCH_PETITON_SUCCESS,
-    petition
-  }))
-
-  testPetitionVariants('FETCH_TOP_PETITIONS_SUCCESS', petition => ({
-    type: FETCH_TOP_PETITIONS_SUCCESS,
-    petitions: [petition]
-  }))
 })


### PR DESCRIPTION
Add a CobrandLogo container that responds to to the organization in the url or loaded petition …

This will display an org logo if there is an orgName specified in the url or the currently loaded petition has a creator.organzation or sponsor.organization.

See this commit for why this wasn't working before https://github.com/MoveOnOrg/mop-frontend/commit/4940e2f3400db9d816b6e18190548f3be62162ae

Fixes #413 