### PR TITLE
Scroll to top on route change

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -129,3 +129,5 @@ export const getPageLoadTime = () => {
   }
   return null
 }
+
+export const scrollToTop = () => window && window.scrollTo(0, 0)

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import { IndexRoute, Route, Router, browserHistory, hashHistory, match } from 'r
 
 
 import { Config } from './config'
+import { scrollToTop } from './lib'
 import { trackPage } from './actions/sessionActions'
 import { loadOrganization } from './actions/navActions.js'
 import Home from './containers/home'
@@ -75,7 +76,7 @@ export const routes = (store) => {
     }
   }
   const routeHierarchy = (
-    <Route path={baseAppPath} component={Wrapper}>
+    <Route path={baseAppPath} component={Wrapper} onChange={scrollToTop}>
       <IndexRoute prodReady component={Home} />
       <Route path='pac/' component={PacHome} />
       <Route path='sign/:petition_slug' component={SignPetition} />


### PR DESCRIPTION
Fixes #414 

This seems like a good default behavior. For me, in chrome at least, the browser overrides this when I go back a page (it maintains previous scroll position).

Also the search results page has it's own scroll behavior for pagination, and that still works (it must fire after the route onChange)

If we want more complicated logic in the future, we can look into https://github.com/taion/react-router-scroll