### PR TITLE
avoid double organization name

### DIFF
--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -157,8 +157,8 @@ const SignatureAddForm = ({
     {showOptinWarning ? (
       <div className='sign-form__agreement'>
         Note: This petition is a project of {creator.organization} and
-        MoveOn.org. By signing, you agree to receive email messages from
-        {creator.organization}, MoveOn Political Action, and MoveOn Civic
+        MoveOn.org. By signing, you agree to receive email messages
+        from {creator.organization}, MoveOn Political Action, and MoveOn Civic
         Action. You may unsubscribe at any time.
       </div>
     ) : (

--- a/src/components/theme-legacy/signature-add-form.js
+++ b/src/components/theme-legacy/signature-add-form.js
@@ -269,8 +269,8 @@ const SignatureAddForm = ({
         {showOptinWarning ? (
           <p className='disclaimer bump-top-1'>
             <b>Note:</b> This petition is a project of {creator.organization} and
-            MoveOn.org. By signing, you agree to receive email messages from
-            <span id='organization_receive'>{creator.organization}, </span>MoveOn
+            MoveOn.org. By signing, you agree to receive email messages
+            from <span id='organization_receive'>{creator.organization}, </span>MoveOn
             Political Action, and MoveOn Civic Action. You may unsubscribe at
             any time.{' '}
             [<Link to='/privacy.html'>Privacy policy</Link>]

--- a/src/containers/sign-petition.js
+++ b/src/containers/sign-petition.js
@@ -100,8 +100,7 @@ class SignPetition extends React.Component {
     const creator = (p._embedded && p._embedded.creator) || {
       name: p.contact_name
     }
-    const petitionBy =
-      creator.name + (creator.organization ? `, ${creator.organization}` : '')
+    const petitionBy = creator.name || p.contact_name
     const outOfDate =
       p.tags && p.tags.filter(t => t.name === 'possibly_out_of_date').length
 

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -216,8 +216,7 @@ class SignatureAddForm extends React.Component {
       innerRef
     } = this.props
     const creator = (petition._embedded && petition._embedded.creator) || {}
-    const petitionBy =
-      creator.name + (creator.organization ? `, ${creator.organization}` : '')
+    const petitionBy = creator.name || petition.contact_name
     return (
       <SignatureAddFormComponent
         submit={this.submit}


### PR DESCRIPTION
fixes #430 
It turns out all the times the org should be listed, it's done on the backend.