### PR TITLE
Add error pages and routes

### DIFF
--- a/docs/EXPLANATION--error-handling.md
+++ b/docs/EXPLANATION--error-handling.md
@@ -1,0 +1,48 @@
+# Error Handling
+
+Because of the various ways mop-frontend fetches data, we should have different ways of detecting errors and displaying them to the user. We should try to reduce the different cases as much as possible, but there is some necessary complexity.
+
+What we have now is just a start, and could be improved upon. (See [Possible Future Work](#possible-future-work))
+
+## /404 and /500
+
+The simplest way of seeing the error pages is going to these routes, defined in routes.js, which simply loads the Error404 or Error500 component as a normal child of Wrapper. Because we don't pass in an `error` prop and they have a `defaultProp.error` of {}, `error.description` returns `undefined` and we always see the default error message defined in the render function.
+
+## Errors in Wrapper
+
+We didn't want to have to change the url to /404 or /500 for every error, so errors can additionally be displayed by the Wrapper, a component that is always on screen (wrapping the current route) and only mounts once. This allows an error to be shown at any route by somehow rendering the error component instead of the Wrapper's normal children.
+
+To do this, there is some logic in Wrapper's render function to display the corresponding error component if `store.errorStore.response_code` is `404` or `500`. We will also override the message on the error page if `store.errorStore.description` is set.
+
+### Setting Error: On Page Load
+
+When the user enters the app at certain special routes, e.g. the petition sign page, the django server provides the app with some data in `window.preloadObjects`. This saves the time of calling the extra `fetch()`.
+
+The user could load the app at a path that the django server recognizes, but some parameter (e.g. petition slug) could be incorrect, or there could be some other server-side issue that means that the server can't provide preload data.
+
+In that case, the server will set `window.error` in the html body. We want to look for this on load and render based on it, so we check the error object in `actions/serverErrorActions.js:checkServerError()`, called on `componentDidMount` of Wrapper (so when the page loads). This function dispatches an action with the contents of any `window.error`, which causes the error to be set in `store.errorStore`.
+
+### Setting Error: From `fetch()`
+
+If we need some data that the server didn't provide in `preloadObjects`, like the user has navigated to a different petition, we fetch the data.
+
+Fetch uses promises, and automatically rejects only if there is a network error.
+
+We can this pattern in an action, which should handle all cases:
+
+
+```js
+fetch(...)
+.catch(rejectNetworkErrorsAs500)
+.then(parseAPIResponse)
+.then(json => dispatch(/*success*/))
+.catch(err => dispatch(/*error*/, error: err))
+```
+because of `catch(rejectNetworkErrorsAs500)` and `then(parseAPIResponse)`, the final catch will be thrown on network errors and api server errors, always being called with `error` as an object with `response_code`.
+
+So in the reducer, we can use this dispatch to set the error on `store.errorStore` and the correct error will be shown in the wrapper like before.
+
+## Possible Future Work
+- More types of error messages (e.g. user has gone offline)
+- Use this fetch() pattern for every fetch()
+- Errors that don't take over the screen.

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -1,5 +1,5 @@
 import Config from '../config.js'
-import { getPageLoadTime, stringifyParams } from '../lib'
+import { getPageLoadTime, stringifyParams, rejectNetworkErrorsAs500, parseAPIResponse } from '../lib'
 import { appLocation } from '../routes.js'
 
 export const actionTypes = {
@@ -55,22 +55,22 @@ export function loadPetition(petitionSlug, forceReload) {
       })
     }
     return fetch(`${Config.API_URI}/${urlKey}.json`)
-      .then(
-        (response) => response.json().then((json) => {
-          dispatch({
-            type: actionTypes.FETCH_PETITION_SUCCESS,
-            petition: json,
-            slug: json.name || petitionSlug
-          })
-        }),
-        (err) => {
-          dispatch({
-            type: actionTypes.FETCH_PETITION_FAILURE,
-            error: err,
-            slug: petitionSlug
-          })
-        }
-      )
+      .catch(rejectNetworkErrorsAs500)
+      .then(parseAPIResponse)
+      .then((json) => {
+        dispatch({
+          type: actionTypes.FETCH_PETITION_SUCCESS,
+          petition: json,
+          slug: json.name || petitionSlug
+        })
+      })
+      .catch(err => {
+        dispatch({
+          type: actionTypes.FETCH_PETITION_FAILURE,
+          error: err,
+          slug: petitionSlug
+        })
+      })
   }
 }
 

--- a/src/actions/serverErrorActions.js
+++ b/src/actions/serverErrorActions.js
@@ -1,0 +1,17 @@
+export const actionTypes = {
+  SERVER_ERROR: 'SERVER_ERROR',
+  SERVER_OK: 'SERVER_OK'
+}
+
+export function checkServerError() {
+  // Will be set on the page by the server
+  if (window && window.error) {
+    return {
+      type: actionTypes.SERVER_ERROR,
+      error: window.error
+    }
+  }
+  return {
+    type: actionTypes.SERVER_OK
+  }
+}

--- a/src/actions/staticPageActions.js
+++ b/src/actions/staticPageActions.js
@@ -1,4 +1,5 @@
 import Config from '../config.js'
+import { parseAPIResponse, rejectNetworkErrorsAs500 } from '../lib'
 
 export const actionTypes = {
   FETCH_PAGE_REQUEST: 'FETCH_PAGE_REQUEST',
@@ -20,20 +21,20 @@ export function loadStaticPage(wordpressId) {
       })
     }
     return fetch(`${Config.WORDPRESS_API_URI}/wp/v2/pages/${wordpressId}`)
-      .then(
-        (response) => response.json().then((json) => {
-          dispatch({
-            type: actionTypes.FETCH_PAGE_SUCCESS,
-            page: json
-          })
-        }),
-        (err) => {
-          dispatch({
-            type: actionTypes.FETCH_PAGE_FAILURE,
-            error: err,
-            wordpressId
-          })
-        }
-      )
+      .catch(rejectNetworkErrorsAs500)
+      .then(parseAPIResponse)
+      .then(page => {
+        dispatch({
+          type: actionTypes.FETCH_PAGE_SUCCESS,
+          page
+        })
+      })
+      .catch(error => {
+        dispatch({
+          type: actionTypes.FETCH_PAGE_FAILURE,
+          error,
+          wordpressId
+        })
+      })
   }
 }

--- a/src/components/theme-giraffe/error404.js
+++ b/src/components/theme-giraffe/error404.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Config from '../../config'
+
 export const Error404 = ({ error: { description } }) => (
   <div className='container'>
     <div className='row my-5'>
@@ -18,7 +20,7 @@ export const Error404 = ({ error: { description } }) => (
           )}
         </p>
         <img
-          src='https://static.moveon.org/giraffe/images/error404.svg'
+          src={`${Config.STATIC_ROOT}error404.svg`}
           alt='404 error'
         />
       </div>

--- a/src/components/theme-giraffe/error404.js
+++ b/src/components/theme-giraffe/error404.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const Error404 = ({ error: { description } }) => (
+  <div className='container'>
+    <div className='row my-5'>
+      <div className='col-12'>
+        <h1 className='text-align-center'>
+          Oops — looks like what you’re looking for isn’t here!
+        </h1>
+        <p className='text-align-center'>
+          {description}
+          {!description && (
+            <span>
+              Email us at <a href='mailto:help@moveon.org'>help@moveon.org</a>{' '}
+              so we can help you find your way.
+            </span>
+          )}
+        </p>
+        <img
+          src='https://static.moveon.org/giraffe/images/error404.svg'
+          alt='404 error'
+        />
+      </div>
+    </div>
+  </div>
+)
+
+Error404.defaultProps = { error: {} }
+Error404.propTypes = { error: PropTypes.object }

--- a/src/components/theme-giraffe/error404.js
+++ b/src/components/theme-giraffe/error404.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import Config from '../../config'
 
+// See /docs/EXPLANATION--error-handling.md for how errors can be shown
 export const Error404 = ({ error: { description } }) => (
   <div className='container'>
     <div className='row my-5'>

--- a/src/components/theme-giraffe/error500.js
+++ b/src/components/theme-giraffe/error500.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const Error500 = ({ error: { description } }) => (
+  <div className='container'>
+    <div className='row my-5'>
+      <div className='col-12 col-md-7'>
+        <h1 className='text-align-center'>
+          Uh-oh — it looks like something went wrong
+        </h1>
+        <p className='text-align-center'>
+          {description}
+          {!description && (
+            <span>
+              We’re sorry about that! Please go back and try again. If you’re
+              still having trouble, shoot us a note at{' '}
+              <a href='mailto:help@moveon.org'>help@moveon.org</a>.
+            </span>
+          )}
+        </p>
+      </div>
+      <div className='col-12 col-md-5 order-md-first'>
+        <img
+          src='https://static.moveon.org/giraffe/images/error500.svg'
+          alt='500 error'
+        />
+      </div>
+    </div>
+  </div>
+)
+
+Error500.defaultProps = { error: {} }
+Error500.propTypes = { error: PropTypes.object }

--- a/src/components/theme-giraffe/error500.js
+++ b/src/components/theme-giraffe/error500.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import Config from '../../config'
 
+// See /docs/EXPLANATION--error-handling.md for how errors can be shown
 export const Error500 = ({ error: { description } }) => (
   <div className='container'>
     <div className='row my-5'>

--- a/src/components/theme-giraffe/error500.js
+++ b/src/components/theme-giraffe/error500.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Config from '../../config'
+
 export const Error500 = ({ error: { description } }) => (
   <div className='container'>
     <div className='row my-5'>
@@ -21,7 +23,7 @@ export const Error500 = ({ error: { description } }) => (
       </div>
       <div className='col-12 col-md-5 order-md-first'>
         <img
-          src='https://static.moveon.org/giraffe/images/error500.svg'
+          src={`${Config.STATIC_ROOT}error500.svg`}
           alt='500 error'
         />
       </div>

--- a/src/components/theme-giraffe/wrapper.js
+++ b/src/components/theme-giraffe/wrapper.js
@@ -12,7 +12,7 @@ const Wrapper = ({ children, organization, minimalNav, entity }) => (
 )
 
 Wrapper.propTypes = {
-  children: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
   organization: PropTypes.string,
   minimalNav: PropTypes.bool,
   entity: PropTypes.string

--- a/src/components/theme-legacy/error404.js
+++ b/src/components/theme-legacy/error404.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export const Error404 = () => (
+  <div className='container background-moveon-white bump-top-1'>
+    <div className='row'>
+      <div className='span6 offset3'>
+        <div className='well'>
+          <h1 className='legend'>Page not found</h1>
+
+          <p>
+            We’re sorry, the page you were looking for has been moved or deleted.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+)

--- a/src/components/theme-legacy/error404.js
+++ b/src/components/theme-legacy/error404.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+// See /docs/EXPLANATION--error-handling.md for how errors can be shown
 export const Error404 = () => (
   <div className='container background-moveon-white bump-top-1'>
     <div className='row'>

--- a/src/components/theme-legacy/error500.js
+++ b/src/components/theme-legacy/error500.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const Error500 = () => (
+  <div className='container background-moveon-white bump-top-1'>
+    <div className='row'>
+      <div className='span6 offset3'>
+        <div className='well'>
+          <h1 className='legend'>Something went wrong</h1>
+          <p>
+            We’re sorry, something went wrong. Please go back and try again. If
+            you’re still having trouble, shoot us a note at{' '}
+            <a href='mailto:help@moveon.org'>help@moveon.org</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+)

--- a/src/components/theme-legacy/error500.js
+++ b/src/components/theme-legacy/error500.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+// See /docs/EXPLANATION--error-handling.md for how errors can be shown
 export const Error500 = () => (
   <div className='container background-moveon-white bump-top-1'>
     <div className='row'>

--- a/src/components/theme-legacy/wrapper.js
+++ b/src/components/theme-legacy/wrapper.js
@@ -18,7 +18,7 @@ const Wrapper = ({ children, minimalNav, entity }) => (
 )
 
 Wrapper.propTypes = {
-  children: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
   minimalNav: PropTypes.bool,
   entity: PropTypes.string
 }

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -3,16 +3,20 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
 import { loadSession } from '../actions/sessionActions'
+import { checkServerError } from '../actions/serverErrorActions'
 
+import { Error404 } from 'Theme/error404'
+import { Error500 } from 'Theme/error500'
 import WrapperComponent from 'Theme/wrapper'
 
 class Wrapper extends React.Component {
   componentDidMount() {
+    this.props.dispatch(checkServerError())
     this.props.dispatch(loadSession(this.props.location))
   }
 
   render() {
-    const { petitionEntity, location, children, routes } = this.props
+    const { petitionEntity, location, children, routes, error } = this.props
     let entity = petitionEntity
     if (location.pathname.indexOf('/pac/') !== -1) {
       entity = 'pac'
@@ -23,7 +27,9 @@ class Wrapper extends React.Component {
         entity={entity}
         minimalNav={!!routes[routes.length - 1].minimalNav}
       >
-        {children}
+        {error.response_code === 404 && <Error404 error={error} />}
+        {error.response_code === 500 && <Error500 error={error} />}
+        {!error.response_code && children}
       </WrapperComponent>
     )
   }
@@ -34,7 +40,8 @@ Wrapper.propTypes = {
   location: PropTypes.object,
   children: PropTypes.object.isRequired,
   routes: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired
+  dispatch: PropTypes.func.isRequired,
+  error: PropTypes.object
 }
 
 function mapStateToProps(store, ownProps) {
@@ -43,7 +50,8 @@ function mapStateToProps(store, ownProps) {
   const petition = petitionSlug && store.petitionStore.petitions[petitionSlug]
 
   return {
-    petitionEntity: petition && petition.entity
+    petitionEntity: petition && petition.entity,
+    error: store.errorStore
   }
 }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -146,3 +146,22 @@ export const getPageLoadTime = () => {
 }
 
 export const scrollToTop = () => window && window.scrollTo(0, 0)
+
+export const rejectNetworkErrorsAs500 = () => Promise.reject({ response_code: 500 })
+
+export const parseAPIResponse = response =>
+  new Promise(resolve => resolve(response.text()))
+    .then(responseBody => {
+      try {
+        const parsedJSON = JSON.parse(responseBody)
+        if (response.ok) return parsedJSON
+        if (!parsedJSON.response_code) throw Error('Response contains no response code')
+        return Promise.reject(parsedJSON)
+      } catch (error) {
+        // The response contains invalid JSON or no response code
+        return Promise.reject({
+          response_code: 500,
+          error
+        })
+      }
+    })

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -1,0 +1,12 @@
+import { actionTypes as serverErrorActionTypes } from '../actions/serverErrorActions'
+
+const reducer = (state = {}, action) => {
+  switch (action.type) {
+    case serverErrorActionTypes.SERVER_ERROR:
+      return action.error
+    default:
+      return state
+  }
+}
+
+export default reducer

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -1,9 +1,11 @@
 import { actionTypes as serverErrorActionTypes } from '../actions/serverErrorActions'
 import { actionTypes as staticPageActionTypes } from '../actions/staticPageActions'
+import { actionTypes as petitionActionTypes } from '../actions/petitionActions'
 
 const reducer = (state = {}, action) => {
   switch (action.type) {
     case staticPageActionTypes.FETCH_PAGE_FAILURE:
+    case petitionActionTypes.FETCH_PETITION_FAILURE:
     case serverErrorActionTypes.SERVER_ERROR:
       return action.error
     default:

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -1,7 +1,9 @@
 import { actionTypes as serverErrorActionTypes } from '../actions/serverErrorActions'
+import { actionTypes as staticPageActionTypes } from '../actions/staticPageActions'
 
 const reducer = (state = {}, action) => {
   switch (action.type) {
+    case staticPageActionTypes.FETCH_PAGE_FAILURE:
     case serverErrorActionTypes.SERVER_ERROR:
       return action.error
     default:

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,6 +3,7 @@ import { actionTypes as petitionActionTypes } from '../actions/petitionActions.j
 import { actionTypes as sessionActionTypes } from '../actions/sessionActions.js'
 import { actionTypes as accountActionTypes } from '../actions/accountActions.js'
 import navStore from './nav'
+import errorReducer from './error'
 import staticPageReducer from './static-pages'
 // Function fetchPetitionRequest(petitionSlug) {
 //     Return {
@@ -267,7 +268,8 @@ const rootReducer = combineReducers({
   petitionSearchStore: petitionSearchReducer,
   userStore: userReducer,
   accountRegisterStore: accountRegisterReducer,
-  staticPageStore: staticPageReducer
+  staticPageStore: staticPageReducer,
+  errorStore: errorReducer
 })
 
 export default rootReducer

--- a/src/routes.js
+++ b/src/routes.js
@@ -55,6 +55,7 @@ const updateHistoryObject = (historyObj, routes) => {
       (error, newlocation, props) => {
         if (!error && props) {
           const matchedComponent = props.routes[props.routes.length - 1]
+
           if (matchedComponent.prodReady || (!Config.ONLY_PROD_ROUTES && Config.BASE_URL !== PROD_URL)) {
             origPush.call(this, matchPath, state)
             return
@@ -119,9 +120,6 @@ export const routes = (store) => {
       {/* Mostly errors will be shown by Wrapper, but these are nice for development */}
       <Route path='404' component={Error404} />
       <Route path='500' component={Error500} />
-
-      {/* Important: THIS HAS TO BE LAST */}
-      <Route path='*' exact component={Error404} />
     </Route>
   )
   updateHistoryObject(appLocation, routeHierarchy)

--- a/src/routes.js
+++ b/src/routes.js
@@ -9,6 +9,8 @@ import { loadOrganization } from './actions/navActions.js'
 
 import Wrapper from './containers/wrapper'
 import ThanksShim from './loaders/thanks-shim'
+import { Error404 } from 'Theme/error404'
+import { Error500 } from 'Theme/error500'
 import Sign from './containers/sign-petition'
 import {
   LoadableHome,
@@ -82,7 +84,7 @@ export const routes = (store) => {
     <Route path={baseAppPath} component={Wrapper} onChange={scrollToTop}>
       <IndexRoute prodReady component={LoadableHome} />
 
-      {/* Sign pages are popular entry page, so they get included in the main bundle (not Loadable) */}
+      {/* Sign pages are popular entry pages, so they get included in the main bundle (not Loadable) */}
       <Route path='sign/:petition_slug' component={Sign} prodReady />
       <Route path=':organization/sign/:petition_slug' component={Sign} onEnter={orgLoader} prodReady />
 
@@ -113,6 +115,13 @@ export const routes = (store) => {
       <Route path='privacy.html' component={LoadableStatic} wordpressId={60950} />
       <Route path='terms.html' component={LoadableStatic} wordpressId={60951} />
       <Route path='victories.html' component={LoadableStatic} wordpressId={61001} />
+
+      {/* Mostly errors will be shown by Wrapper, but these are nice for development */}
+      <Route path='404' component={Error404} />
+      <Route path='500' component={Error500} />
+
+      {/* Important: THIS HAS TO BE LAST */}
+      <Route path='*' exact component={Error404} />
     </Route>
   )
   updateHistoryObject(appLocation, routeHierarchy)


### PR DESCRIPTION
Closes partially #412 

I added some docs here https://github.com/MoveOnOrg/mop-frontend/blob/5832a82a8a1c04f66d5071c5fdfb446680cbecf9/docs/EXPLANATION--error-handling.md

- [x] Add legacy error pages
- [x] Add giraffe error pages
- [x] Show error if window.error is set
- [x] Show error on loading petition page with `fetch()` error
  - [x] Server doesn't respond (user could be offline)
  - [x] Server returns error status code
- [ ] Show error on signing petition with `fetch()` error
  - [ ] Server doesn't respond (user could be offline)
  - [ ] Server returns error status code
- [x] Show error on static pages with `fetch()` error
  - [x] Server doesn't respond (user could be offline)
  - [x] Server returns error status code