### PR TITLE
Better email validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "core-js": "^2.5.3",
+    "email-regex": "^2.0.0",
     "osdi-client": "MoveOnOrg/osdi-client",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import emailRegex from 'email-regex'
 
 import SignatureAddFormComponent from 'Theme/signature-add-form'
 
@@ -32,7 +33,7 @@ class SignatureAddForm extends React.Component {
       required: {}
     }
     this.validationRegex = {
-      email: /.+@.+\..+/, // Forgiving email regex
+      email: emailRegex({ exact: true }),
       zip: /(\d\D*){5}/,
       phone: /(\d\D*){10}/ // 10-digits
     }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,5 @@
 import React from 'react' // needed to get JSX in scope for text2paraJsx
+import emailRegex from 'email-regex'
 import Config from '../config'
 
 export { getStateFullName, getRegions, armedForcesRegions } from './state-abbrev'
@@ -93,7 +94,7 @@ export const petitionShortCode = (mode, petitionId, userId, responseMd5) => {
 }
 
 export const isValidEmail = (email) => {
-  const regex = /.+@.+\..+/ // Forgiving email regex
+  const regex = emailRegex({ exact: true })
   return regex.test(email)
 }
 


### PR DESCRIPTION
Fixes #453 

Uses [email-regex](https://github.com/sindresorhus/email-regex/blob/master/index.js)

```
/^[^\.\s@:][^\s@:]*(?!\.)@[^\.\s@]+(?:\.[^\.\s@]+)*$/
> t.test('justin@example.com')
true
> t.test('justin@example .com')
false
> t.test('justin@example..com')
false
> t.test('foo@yahoo.com h')
false
> t.test('foo+123@yahoo.com')
true
> t.test('é13@yahoo.com')
true
```