### PR TITLE
Clear any error in redux on route change

### DIFF
--- a/docs/EXPLANATION--error-handling.md
+++ b/docs/EXPLANATION--error-handling.md
@@ -14,6 +14,8 @@ We didn't want to have to change the url to /404 or /500 for every error, so err
 
 To do this, there is some logic in Wrapper's render function to display the corresponding error component if `store.errorStore.response_code` is `404` or `500`. We will also override the message on the error page if `store.errorStore.description` is set.
 
+We also need to clear this error in the router's `onChange` callback, so if they navigate to another page, or go back or something, this error is cleared and they can see the page contents again.
+
 ### Setting Error: On Page Load
 
 When the user enters the app at certain special routes, e.g. the petition sign page, the django server provides the app with some data in `window.preloadObjects`. This saves the time of calling the extra `fetch()`.

--- a/src/actions/serverErrorActions.js
+++ b/src/actions/serverErrorActions.js
@@ -1,6 +1,7 @@
 export const actionTypes = {
   SERVER_ERROR: 'SERVER_ERROR',
-  SERVER_OK: 'SERVER_OK'
+  SERVER_OK: 'SERVER_OK',
+  CLEAR_ERROR: 'CLEAR_ERROR'
 }
 
 export function checkServerError() {
@@ -14,4 +15,8 @@ export function checkServerError() {
   return {
     type: actionTypes.SERVER_OK
   }
+}
+
+export function clearError() {
+  return { type: actionTypes.CLEAR_ERROR }
 }

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -8,6 +8,8 @@ const reducer = (state = {}, action) => {
     case petitionActionTypes.FETCH_PETITION_FAILURE:
     case serverErrorActionTypes.SERVER_ERROR:
       return action.error
+    case serverErrorActionTypes.CLEAR_ERROR:
+      return {}
     default:
       return state
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,7 +5,8 @@ import { IndexRoute, Route, Router, browserHistory, hashHistory, match } from 'r
 import { Config } from './config'
 import { scrollToTop } from './lib'
 import { trackPage } from './actions/sessionActions'
-import { loadOrganization } from './actions/navActions.js'
+import { loadOrganization } from './actions/navActions'
+import { clearError } from './actions/serverErrorActions'
 
 import Wrapper from './containers/wrapper'
 import ThanksShim from './loaders/thanks-shim'
@@ -81,8 +82,12 @@ export const routes = (store) => {
       store.dispatch(loadOrganization(nextState.params.organization))
     }
   }
+  const onChange = () => {
+    store.dispatch(clearError()) // Stop showing any error page
+    scrollToTop()
+  }
   const routeHierarchy = (
-    <Route path={baseAppPath} component={Wrapper} onChange={scrollToTop}>
+    <Route path={baseAppPath} component={Wrapper} onChange={onChange}>
       <IndexRoute prodReady component={LoadableHome} />
 
       {/* Sign pages are popular entry pages, so they get included in the main bundle (not Loadable) */}


### PR DESCRIPTION
Fix for #450 

We need to clear the error in the router's `onChange` callback, so if the user navigates to another page, or goes back or something, this error is cleared and they can see page contents again.