### PR TITLE
Error handling for submitting signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build
 .\#*
 .env
 npm-debug.log
+package-lock.json
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "directories": {},
   "scripts": {
     "test": "NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --require babel-core/register --require jsdom-global/register --require isomorphic-fetch --require ./test-setup.js --recursive",
-    "test:coverage": "nyc npm test",
+    "test:coverage": "nyc --reporter=html --reporter=text npm test",
     "build": "THEME=legacy webpack && THEME=giraffe webpack",
     "dev-build": "THEME=legacy webpack -d && THEME=giraffe webpack -d",
     "webpack-watch": "webpack -w",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-react": "^5.2.2",
+    "fetch-mock": "^5.1.5",
     "file-loader": "^0.11.1",
     "html-webpack-plugin": "^2.22.0",
     "isomorphic-fetch": "^2.2.1",

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -223,7 +223,7 @@ export function signPetition(petitionSignature, petition, options) {
     }
     const fetchArgs = {
       method: 'POST',
-      body: JSON.stringify(petitionSignature),
+      body: JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json'

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -4,9 +4,10 @@ import { connect } from 'react-redux'
 
 import SignatureAddFormComponent from 'Theme/signature-add-form'
 
-import { actions as petitionActions } from '../actions/petitionActions.js'
+import { signPetition, devLocalSignPetition } from '../actions/petitionActions.js'
 import { actions as sessionActions } from '../actions/sessionActions.js'
 import { isValidEmail } from '../lib'
+import Config from '../config'
 
 class SignatureAddForm extends React.Component {
 
@@ -199,9 +200,12 @@ class SignatureAddForm extends React.Component {
   submit(event) {
     event.preventDefault()
     const { dispatch, petition } = this.props
+    // In dev, by default, don't actually call the api
+    const signAction = Config.API_WRITABLE ? signPetition : devLocalSignPetition
+
     if (this.formIsValid()) {
       const osdiSignature = this.getOsdiSignature()
-      dispatch(petitionActions.signPetition(osdiSignature, petition, { redirectOnSuccess: true }))
+      dispatch(signAction(osdiSignature, petition, { redirectOnSuccess: true }))
     }
     return false
   }

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
+import { scrollToTop } from '../lib'
 import { loadSession } from '../actions/sessionActions'
 import { checkServerError } from '../actions/serverErrorActions'
 
@@ -13,6 +14,14 @@ class Wrapper extends React.Component {
   componentDidMount() {
     this.props.dispatch(checkServerError())
     this.props.dispatch(loadSession(this.props.location))
+  }
+
+  componentDidUpdate() {
+    if (this.props.error && this.props.error.response_code) {
+      // Normally we scroll to top on route change, however we can display an
+      // error without a route change
+      scrollToTop()
+    }
   }
 
   render() {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -165,3 +165,22 @@ export const parseAPIResponse = response =>
         })
       }
     })
+
+export const parseSQSApiResponse = response =>
+  new Promise(resolve => resolve(response.text()))
+    .then(responseBody => {
+      try {
+        const parsedJSON = JSON.parse(responseBody)
+        if (response.ok && !parsedJSON.Error) return parsedJSON
+        return Promise.reject({
+          response_code: 500,
+          error: parsedJSON
+        })
+      } catch (error) {
+        // The response contains invalid JSON or no response code
+        return Promise.reject({
+          response_code: 500,
+          error
+        })
+      }
+    })

--- a/src/reducers/error.js
+++ b/src/reducers/error.js
@@ -6,6 +6,7 @@ const reducer = (state = {}, action) => {
   switch (action.type) {
     case staticPageActionTypes.FETCH_PAGE_FAILURE:
     case petitionActionTypes.FETCH_PETITION_FAILURE:
+    case petitionActionTypes.PETITION_SIGNATURE_FAILURE:
     case serverErrorActionTypes.SERVER_ERROR:
       return action.error
     case serverErrorActionTypes.CLEAR_ERROR:

--- a/test/actions/petitionActions.js
+++ b/test/actions/petitionActions.js
@@ -27,7 +27,7 @@ const PETITION = {
   anything: true
 }
 
-describe('petitionActions', () => {
+describe('petitionActions signPetition configured as prod', () => {
   let prevSign
   let prevWritable
   before(() => {
@@ -35,40 +35,6 @@ describe('petitionActions', () => {
     prevWritable = Config.API_WRITABLE
     Config.API_SIGN_PETITION = 'https://petitions.example.com/api-v1-signatures'
     Config.API_WRITABLE = true
-  })
-
-  it('still dispatches success if endpoint returns 500', done => {
-    fetchMock.post('https://petitions.example.com/api-v1-signatures', { status: 500 })
-    const dispatch = sinon.spy(() => {
-      if (dispatch.callCount === 2) {
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          'PETITION_SIGNATURE_SUBMIT'
-        )
-        expect(dispatch.secondCall.args[0].type).to.equal(
-          'PETITION_SIGNATURE_SUCCESS'
-        )
-        done()
-        fetchMock.restore()
-      }
-    })
-    signPetition(SIGNATURE, PETITION)(dispatch)
-  })
-
-  it('dispatches failure when `fetch` throws (network error)', done => {
-    fetchMock.post('https://petitions.example.com/api-v1-signatures', { throws: new TypeError() })
-    const dispatch = sinon.spy(() => {
-      if (dispatch.callCount === 2) {
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          'PETITION_SIGNATURE_SUBMIT'
-        )
-        expect(dispatch.secondCall.args[0].type).to.equal(
-          'PETITION_SIGNATURE_FAILURE'
-        )
-        done()
-        fetchMock.restore()
-      }
-    })
-    signPetition(SIGNATURE, PETITION)(dispatch)
   })
 
   it('calls sign petition endpoint', done => {
@@ -86,15 +52,109 @@ describe('petitionActions', () => {
         expect(dispatch.secondCall.args[0].type).to.equal(
           'PETITION_SIGNATURE_SUCCESS'
         )
+        expect(dispatch.secondCall.args[0].messageId).to.equal('jkl3')
+        expect(dispatch.secondCall.args[0].petition).to.equal(PETITION)
         done()
-        fetchMock.restore()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+
+  it('dispatches failure if endpoint returns invalid json', done => {
+    fetchMock.post('https://petitions.example.com/api-v1-signatures', { status: 200 })
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_FAILURE'
+        )
+        done()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+
+  it('dispatches failure when `fetch` throws (network error)', done => {
+    fetchMock.post('https://petitions.example.com/api-v1-signatures', { throws: new TypeError() })
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_FAILURE'
+        )
+        done()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+
+  afterEach(() => fetchMock.restore())
+
+  after(() => {
+    Config.API_SIGN_PETITION = prevSign
+    Config.API_WRITABLE = prevWritable
+  })
+})
+
+
+describe('petitionActions signPetition configured dev', () => {
+  let prevApi
+  let prevWritable
+  before(() => {
+    prevWritable = Config.API_WRITABLE
+    prevApi = Config.API_URI
+    Config.API_WRITABLE = false
+    Config.API_URI = 'http://localhost:4174'
+  })
+
+  afterEach(() => fetchMock.restore())
+
+  it('doesn’t fetch and returns success', done => {
+    fetchMock.mock('*', 200)
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(fetchMock.called()).to.equal(false)
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUCCESS'
+        )
+        expect(dispatch.secondCall.args[0].petition).to.equal(PETITION)
+        done()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+
+  it('can write to fake api', done => {
+    Config.API_WRITABLE = 'fake'
+    fetchMock.get('http://localhost:4174/signatures.json', SQS_RESPONSE)
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(fetchMock.lastUrl()).to.equal('http://localhost:4174/signatures.json')
+        const opts = fetchMock.lastOptions()
+        expect(opts.method).to.equal('GET')
+        expect(opts.body).to.equal(undefined)
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUCCESS'
+        )
+        expect(dispatch.secondCall.args[0].petition).to.equal(PETITION)
+        done()
       }
     })
     signPetition(SIGNATURE, PETITION)(dispatch)
   })
 
   after(() => {
-    Config.API_SIGN_PETITION = prevSign
     Config.API_WRITABLE = prevWritable
+    Config.API_URI = prevApi
   })
 })

--- a/test/actions/petitionActions.js
+++ b/test/actions/petitionActions.js
@@ -1,0 +1,65 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import fetchMock from 'fetch-mock'
+import Config from '../../src/config'
+
+import { signPetition } from '../../src/actions/petitionActions'
+
+const SQS_RESPONSE = {
+  SendMessageResponse: {
+    ResponseMetadata: { RequestId: 'abc' },
+    SendMessageResult: {
+      MD5OfMessageAttributes: 'def',
+      MD5OfMessageBody: 'ghi',
+      MessageId: 'jkl3',
+      SequenceNumber: null
+    }
+  }
+}
+
+const SIGNATURE = {
+  signature: true,
+  anything: true
+}
+
+const PETITION = {
+  petition: true,
+  anything: true
+}
+
+describe('petitionActions', () => {
+  let prevSign
+  let prevWritable
+  before(() => {
+    prevSign = Config.API_SIGN_PETITION
+    prevWritable = Config.API_WRITABLE
+    Config.API_SIGN_PETITION = 'https://petitions.example.com/api-v1-signatures'
+    Config.API_WRITABLE = true
+    fetchMock.post('https://petitions.example.com/api-v1-signatures', SQS_RESPONSE)
+  })
+
+  it('calls sign petition endpoint', done => {
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(fetchMock.lastUrl()).to.equal('https://petitions.example.com/api-v1-signatures')
+        const opts = fetchMock.lastOptions()
+        expect(opts.method).to.equal('POST')
+        expect(opts.body).to.equal(JSON.stringify(SIGNATURE))
+
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUCCESS'
+        )
+        done()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+  after(() => {
+    fetchMock.restore()
+    Config.API_SIGN_PETITION = prevSign
+    Config.API_WRITABLE = prevWritable
+  })
+})

--- a/test/actions/petitionActions.js
+++ b/test/actions/petitionActions.js
@@ -194,7 +194,7 @@ describe('petitionActions signPetition configured dev', () => {
     devLocalSignPetition(SIGNATURE, PETITION)(dispatch)
   })
 
-  it('can write to fake api', done => {
+  it('can get fake sqs response from local api', done => {
     Config.API_WRITABLE = 'fake'
     fetchMock.get('http://localhost:4174/signatures.json', SQS_RESPONSE)
     const dispatch = sinon.spy(() => {

--- a/test/actions/petitionActions.js
+++ b/test/actions/petitionActions.js
@@ -37,15 +37,10 @@ describe('petitionActions', () => {
     Config.API_WRITABLE = true
   })
 
-  it('calls sign petition endpoint', done => {
-    fetchMock.post('https://petitions.example.com/api-v1-signatures', SQS_RESPONSE)
+  it('still dispatches success if endpoint returns 500', done => {
+    fetchMock.post('https://petitions.example.com/api-v1-signatures', { status: 500 })
     const dispatch = sinon.spy(() => {
       if (dispatch.callCount === 2) {
-        expect(fetchMock.lastUrl()).to.equal('https://petitions.example.com/api-v1-signatures')
-        const opts = fetchMock.lastOptions()
-        expect(opts.method).to.equal('POST')
-        expect(opts.body).to.equal(JSON.stringify(SIGNATURE))
-
         expect(dispatch.firstCall.args[0].type).to.equal(
           'PETITION_SIGNATURE_SUBMIT'
         )
@@ -68,6 +63,28 @@ describe('petitionActions', () => {
         )
         expect(dispatch.secondCall.args[0].type).to.equal(
           'PETITION_SIGNATURE_FAILURE'
+        )
+        done()
+        fetchMock.restore()
+      }
+    })
+    signPetition(SIGNATURE, PETITION)(dispatch)
+  })
+
+  it('calls sign petition endpoint', done => {
+    fetchMock.post('https://petitions.example.com/api-v1-signatures', SQS_RESPONSE)
+    const dispatch = sinon.spy(() => {
+      if (dispatch.callCount === 2) {
+        expect(fetchMock.lastUrl()).to.equal('https://petitions.example.com/api-v1-signatures')
+        const opts = fetchMock.lastOptions()
+        expect(opts.method).to.equal('POST')
+        expect(opts.body).to.equal(JSON.stringify(SIGNATURE))
+
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUBMIT'
+        )
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          'PETITION_SIGNATURE_SUCCESS'
         )
         done()
         fetchMock.restore()

--- a/test/actions/petitionActions.js
+++ b/test/actions/petitionActions.js
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import fetchMock from 'fetch-mock'
 import Config from '../../src/config'
 
-import { signPetition } from '../../src/actions/petitionActions'
+import { signPetition, devLocalSignPetition } from '../../src/actions/petitionActions'
 
 const SQS_RESPONSE = {
   SendMessageResponse: {
@@ -80,6 +80,7 @@ describe('petitionActions signPetition configured as prod', () => {
     fetchMock.post('https://petitions.example.com/api-v1-signatures', { throws: new TypeError() })
     const dispatch = sinon.spy(() => {
       if (dispatch.callCount === 2) {
+        expect(fetchMock.called()).to.equal(true)
         expect(dispatch.firstCall.args[0].type).to.equal(
           'PETITION_SIGNATURE_SUBMIT'
         )
@@ -128,7 +129,7 @@ describe('petitionActions signPetition configured dev', () => {
         done()
       }
     })
-    signPetition(SIGNATURE, PETITION)(dispatch)
+    devLocalSignPetition(SIGNATURE, PETITION)(dispatch)
   })
 
   it('can write to fake api', done => {


### PR DESCRIPTION
Adds tests and refactors signPetition to dispatch error actions on bad things from SQS. We also add this failure to the reducer so an error screen will be shown in this case.

We handle errors in a similar way to https://github.com/MoveOnOrg/mop-frontend/pull/450

closes #412