### PR TITLE
anonymous segment tracking -- even if we do not have a cookie, etc

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -17,10 +17,18 @@ export function unRecognize() {
 
 let hasIdentified = false
 function identify(id) {
-  if (hasIdentified || !id || !window.analytics || !window.analytics.identify) return
+  // segment tracking
+  if (hasIdentified || !window.analytics || !window.analytics.identify) return
 
-  window.analytics.identify(id) // segment tracking
-  hasIdentified = true
+  if (!id) {
+    const anonId = String(Math.random()).substr(2)
+    window.analytics.identify(`anon${anonId}`)
+    // We don't mark it as hasIdentified in this branch because
+    // if we load up session info, it might be non-anonymous
+  } else {
+    window.analytics.identify(id)
+    hasIdentified = true
+  }
 }
 
 function callSessionApi(tokens) {
@@ -47,10 +55,6 @@ function callSessionApi(tokens) {
               trackIdentity = id.substring('actionkit:'.length)
             }
           })
-          if (!trackIdentity) {
-            const anonId = String(Math.random()).substr(2)
-            trackIdentity = `anon${anonId}`
-          }
           identify(trackIdentity)
         }
       }),
@@ -85,6 +89,8 @@ export const loadSession = (location) => {
       tokens.hashedId = id
     }
     return callSessionApi(tokens)
+  } else {
+    identify() // anonymous session tracking
   }
   // If there was no cookie or tokens, we don't even need to call the api
   return (dispatch) => {

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -89,9 +89,10 @@ export const loadSession = (location) => {
       tokens.hashedId = id
     }
     return callSessionApi(tokens)
-  } else {
-    identify() // anonymous session tracking
   }
+
+  identify() // anonymous session tracking
+
   // If there was no cookie or tokens, we don't even need to call the api
   return (dispatch) => {
     dispatch({


### PR DESCRIPTION
For completely anonymous visits we weren't tracking this because they don't even have a cookie.

This should fix that.