### PR TITLE
Make sure tree shaking is working

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets" : ["es2015", "react"],
+  "presets": [["es2015", { "modules": false }], "react"],
   "plugins": [
     ["transform-object-rest-spread", { "useBuiltIns": false }],
     "syntax-dynamic-import"

--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,11 @@
   ],
   "env": {
     "test": {
-      "plugins": ["webpack-alias", "dynamic-import-node"]
+      "plugins": [
+        "webpack-alias",
+        "dynamic-import-node",
+        "transform-es2015-modules-commonjs"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-loader": "^7.1.4",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-webpack-alias": "^2.1.2",
     "babel-preset-es2015": "^6.18.0",

--- a/src/components/theme-legacy/petition-report.js
+++ b/src/components/theme-legacy/petition-report.js
@@ -78,5 +78,3 @@ PetitionReport.propTypes = {
   petition: PropTypes.object,
   signatureStats: PropTypes.object
 }
-
-export default PetitionReport

--- a/src/containers/petition-report.js
+++ b/src/containers/petition-report.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import { PetitionReportComponent } from 'LegacyTheme/petition-report'
+import { PetitionReport as PetitionReportComponent } from 'LegacyTheme/petition-report'
 import { loadPetition } from '../actions/petitionActions'
 
 class PetitionReport extends React.Component {


### PR DESCRIPTION
Apparently using `modules: false` stops babel from making cjs modules and allows webpack to optimize the modules itself, which includes tree shaking.

https://wetainment.com/tree-shaking/

Saves us a cool 17kb on the main bundle. 226kb -> 209kb

It also found a module bug somehow 😁 
