### PR TITLE
Fix external links sometimes not working

### DIFF
--- a/src/components/theme-giraffe/footer.js
+++ b/src/components/theme-giraffe/footer.js
@@ -20,31 +20,29 @@ export const Footer = ({ entity }) => (
     <MoFooter.Top>
       <Nav>
         <Nav.Links heading='Organization'>
-          <Link to='https://front.moveon.org/careers'>Careers</Link>
-          <Link to='https://front.moveon.org/blog/'>News</Link>
-          <Link to='https://www.facebook.com/moveon/videos'>Videos</Link>
-          <Link to='https://act.moveon.org/signup/signup'>
-            Sign Up for Emails
-          </Link>
-          <Link to='https://act.moveon.org/survey/get-texts-moveon/'>
+          <a href='https://front.moveon.org/careers'>Careers</a>
+          <a href='https://front.moveon.org/blog/'>News</a>
+          <a href='https://www.facebook.com/moveon/videos'>Videos</a>
+          <a href='https://act.moveon.org/signup/signup'>Sign Up for Emails</a>
+          <a href='https://act.moveon.org/survey/get-texts-moveon/'>
             Sign up for Text Msg Alerts
-          </Link>
+          </a>
         </Nav.Links>
         <Nav.Links heading='Contact'>
-          <Link to='http://moveon.desk.com/customer/portal/emails/new'>
+          <a href='http://moveon.desk.com/customer/portal/emails/new'>
             General Inquiries
-          </Link>
+          </a>
           <Link to='/feedback.html'>Petition Inquiries</Link>
-          <Link to='https://act.moveon.org/survey/press/'>Press Inquiries</Link>
+          <a href='https://act.moveon.org/survey/press/'>Press Inquiries</a>
           <Link to='/organizations.html'>Partner with Us</Link>
         </Nav.Links>
         <Nav.Links heading='Support'>
-          <Link to='https://front.moveon.org/frequently-asked-questions-and-contact-information-2/'>
+          <a href='https://front.moveon.org/frequently-asked-questions-and-contact-information-2/'>
             FAQs
-          </Link>
-          <Link to='https://front.moveon.org/privacy-policy/'>
+          </a>
+          <a href='https://front.moveon.org/privacy-policy/'>
             Privacy Policy and ToS
-          </Link>
+          </a>
         </Nav.Links>
         <Nav.CallToAction
           copy={
@@ -54,7 +52,7 @@ export const Footer = ({ entity }) => (
             </span>
           }
         >
-          <Link to='http://petitions.moveon.org/create_start.html?source=homepage'>
+          <Link to='/create_start.html?source=petitionfooter'>
             <DocumentSvg />
             Start A Petition
             <CaretRightSvg />

--- a/src/components/theme-giraffe/nav.js
+++ b/src/components/theme-giraffe/nav.js
@@ -36,7 +36,7 @@ const Nav = ({
 
           {/* More Top level */}
           <NavLink href='https://moveon.org/events'>Events</NavLink>
-          <NavLink to='https://front.moveon.org/about'>About Us</NavLink>
+          <NavLink href='https://front.moveon.org/about'>About Us</NavLink>
         </Primary>
         <Secondary>
           <Secondary.Top>

--- a/src/components/theme-giraffe/nav.js
+++ b/src/components/theme-giraffe/nav.js
@@ -27,25 +27,25 @@ const Nav = ({
           </Primary.Section>
 
           <Primary.Section name='Campaigns'>
-            <NavLink to='https://moveon.org/browse-campaigns'>
+            <NavLink href='https://moveon.org/browse-campaigns'>
               Browse Campaigns
             </NavLink>
-            <NavLink to='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
-            <NavLink to='https://moveon.org/our-impact'>Our Impact</NavLink>
+            <NavLink href='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
+            <NavLink href='https://moveon.org/our-impact'>Our Impact</NavLink>
           </Primary.Section>
 
           {/* More Top level */}
-          <NavLink to='https://moveon.org/events'>Events</NavLink>
+          <NavLink href='https://moveon.org/events'>Events</NavLink>
           <NavLink to='https://front.moveon.org/about'>About Us</NavLink>
         </Primary>
         <Secondary>
           <Secondary.Top>
-            <NavLink to='https://front.moveon.org/blog'>News</NavLink>
-            <NavLink to='https://store.moveon.org'>Store</NavLink>
+            <NavLink href='https://front.moveon.org/blog'>News</NavLink>
+            <NavLink href='https://store.moveon.org'>Store</NavLink>
           </Secondary.Top>
           <Secondary.Bottom>
-            <NavLink to='https://front.moveon.org/#join'>Join</NavLink>
-            <NavLink to='https://act.moveon.org/donate/civ-donation?utm_source=petitions_nav&source=petitions_nav'>
+            <NavLink href='https://front.moveon.org/#join'>Join</NavLink>
+            <NavLink href='https://act.moveon.org/donate/civ-donation?utm_source=petitions_nav&source=petitions_nav'>
               Donate
             </NavLink>
             <NavLink to='/create_start.html?source=topnav'>

--- a/src/giraffe-ui/footer/pac-fine-print.js
+++ b/src/giraffe-ui/footer/pac-fine-print.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Link } from 'react-router'
+
 export const PACFinePrint = () => (
   <div className='footer__fineprint'>
     Paid for in part by{' '}
-    <Link to='http://pol.moveon.org/'>
+    <a href='http://pol.moveon.org/'>
       <strong>MoveOn Political Action</strong>
-    </Link>. Not authorized by any candidate or candidate’s committee.
+    </a>. Not authorized by any candidate or candidate’s committee.
   </div>
 )

--- a/src/giraffe-ui/footer/social.js
+++ b/src/giraffe-ui/footer/social.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router'
 
 import FacebookSvg from '../svgs/facebook.svg'
 import TwitterSvg from '../svgs/twitter.svg'
@@ -7,15 +6,15 @@ import InstagramSvg from '../svgs/instagram.svg'
 
 export const Social = () => (
   <div className='footer__social'>
-    <Link to='http://www.facebook.com/moveon'>
+    <a href='http://www.facebook.com/moveon'>
       <FacebookSvg />
-    </Link>
-    <Link to='http://www.twitter.com/moveon'>
+    </a>
+    <a href='http://www.twitter.com/moveon'>
       <TwitterSvg />
-    </Link>
-    <Link to='https://www.instagram.com/moveon'>
+    </a>
+    <a href='https://www.instagram.com/moveon'>
       <InstagramSvg />
-    </Link>
+    </a>
   </div>
 )
 

--- a/src/giraffe-ui/footer/text.js
+++ b/src/giraffe-ui/footer/text.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router'
 
 import CaretRightSvg from '../svgs/caret-right.svg'
 
@@ -11,29 +10,29 @@ export const Text = () => (
       separate organizations.
     </div>
     <div className='footer__text__item'>
-      <Link to='http://civic.moveon.org/'>MoveOn.org Civic Action</Link> is a
+      <a href='http://civic.moveon.org/'>MoveOn.org Civic Action</a> is a
       501(c)(4) organization which primarily focuses on nonpartisan education
       and advocacy on important national issues.
-      <Link
-        to='https://civic.moveon.org/donatec4/creditcard.html?cpn_id=511'
+      <a
+        href='https://civic.moveon.org/donatec4/creditcard.html?cpn_id=511'
         className='footer__text__cta'
       >
         Donate to MoveOn Civic Action
         <CaretRightSvg />
-      </Link>
+      </a>
     </div>
     <div className='footer__text__item'>
-      <Link to='http://pol.moveon.org/'>MoveOn.org Political Action</Link> is a
+      <a href='http://pol.moveon.org/'>MoveOn.org Political Action</a> is a
       federal political committee which primarily helps members elect candidates
       who reflect our values through a variety of activities aimed at
       influencing the outcome of the next election.
-      <Link
-        to='https://act.moveon.org/donate/pac-donation'
+      <a
+        href='https://act.moveon.org/donate/pac-donation'
         className='footer__text__cta'
       >
         Donate to MoveOn Political Action
         <CaretRightSvg />
-      </Link>
+      </a>
     </div>
   </div>
 )

--- a/src/giraffe-ui/nav/navlink.js
+++ b/src/giraffe-ui/nav/navlink.js
@@ -2,13 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
-export const NavLink = ({ to, children }) => (
+export const NavLink = ({ to, href, children }) => (
   <li>
-    <Link to={to}>{children}</Link>
+    {to && <Link to={to}>{children}</Link>}
+    {!to && href && <a href={href}>{children}</a>}
   </li>
 )
 
 NavLink.propTypes = {
   to: PropTypes.string,
+  href: PropTypes.string,
   children: PropTypes.node
 }


### PR DESCRIPTION
Makes links that go outside of petitions use regular `<a href/>` instead of react router `<Link/>`

This was working in some cases before, because of how we patched `location.push`, but it turns out that it was in other cases matching routes based on the path, regardless of the domain, leading to things like #477, caused by `<Link to='https://store.moveon.org/'>` matching `<Route path='/'>`.

These external links would only redirect if they didn't match any routes. We could have fixed this by adding more special cases to our `location.push` code, but additionally react router was warning us about this:
```
Warning: A path must be pathname + search + hash only, not a full URL like "https://front.moveon.org/#join"
```
So I decided it's better to work with react-router closer to how it expects, and to replace all of these external links with regular html links.

fixes #477 