### PR TITLE
Fix loading of signatures when navigating to a petition from homepage

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -130,11 +130,17 @@ function petitionReducer(state = initialPetitionState, action) {
         return state
       }
       updateData = {
-        petitions: Object.assign({}, state.petitions,
-                                 ...petitions.map((topPetition) => ({
-                                   [topPetition.name]: topPetition,
-                                   [topPetition.petition_id]: topPetition
-                                 }))),
+        petitions: Object.assign(
+          {},
+          state.petitions,
+          ...petitions.map(topPetition => {
+            const p = { ...topPetition, ...{ slug: topPetition.name } }
+            return {
+              [topPetition.name]: p,
+              [topPetition.petition_id]: p
+            }
+          })
+        ),
         topPetitions: {
           ...state.topPetitions,
           [topPetitionsKey]: petitions.map(topPetition => topPetition.petition_id)


### PR DESCRIPTION
Steps to reproduce:
1. Visit https://petitions.moveon.org
1. Click on a top petition
1. See that the first page of signatures isn't loaded.

This is because we cache the top petitions in the petitionStore without the slug key, as opposed to regularly loaded petitions, which get their slug from here https://github.com/MoveOnOrg/mop-frontend/blob/main/src/reducers/index.js#L68-L69.

This breaks the signature list, which tries to try to load the signatures using `petition.slug` https://github.com/MoveOnOrg/mop-frontend/blob/main/src/actions/petitionActions.js#L306.

To fix, I assign `petition.name` as `petition.slug` for each petition when fetching top petitions.