### PR TITLE
Fix loading of signatures when navigating to a petition from homepage

### DIFF
--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -303,7 +303,7 @@ export const recordShareClick = (petition, tracking, medium, source, user) => {
 
 export const loadPetitionSignatures = (petition, page = 1) => {
   const petitionListId = getPetitionListId(petition)
-  const petitionSlug = petition.slug
+  const petitionSlug = petition.name
   const urlKey = (petitionListId
                   ? `petitions/list${petitionListId}/signatures`
                   : `petitions/${petitionSlug}/signatures`)

--- a/src/components/theme-legacy/signature-add-form.js
+++ b/src/components/theme-legacy/signature-add-form.js
@@ -295,7 +295,7 @@ const SignatureAddForm = ({
         className='codebox percent-95 hidden-phone moveon-track-click'
       >
         {`<iframe src="https://petitions.moveon.org/embed/widget.html?v=3&name=${
-          petition.slug
+          petition.name
         }" class="moveon-petition" id="petition-embed" width="300px" height="500px"></iframe>`}
       </div>
     </div>

--- a/src/containers/signature-list.js
+++ b/src/containers/signature-list.js
@@ -81,7 +81,7 @@ SignatureList.propTypes = {
 }
 
 const mapStateToProps = (store, ownProps) => ({
-  signatures: store.petitionStore.petitionSignatures[ownProps.petition.slug]
+  signatures: store.petitionStore.petitionSignatures[ownProps.petition.name]
 })
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
Steps to reproduce:

1. Visit https://petitions.moveon.org
1. Click on a top petition
1. See that the first page of signatures isn't loaded.

This is because we cache the top petitions in the petitionStore without the slug key, as opposed to regularly loaded petitions, which get their slug from here https://github.com/MoveOnOrg/mop-frontend/blob/main/src/reducers/index.js#L68-L69.

This breaks the signature list, which tries to try to load the signatures using petition.slug https://github.com/MoveOnOrg/mop-frontend/blob/main/src/containers/signature-list.js#L84

To fix, we use petition.name instead of petition.slug (also everywhere else it's used)