### PR TITLE
updated nav campaign tips link to proxy version

### DIFF
--- a/src/components/theme-giraffe/nav.js
+++ b/src/components/theme-giraffe/nav.js
@@ -30,7 +30,7 @@ const Nav = ({
             <NavLink href='https://moveon.org/browse-campaigns'>
               Browse Campaigns
             </NavLink>
-            <NavLink to='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
+            <NavLink href='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
             <NavLink href='https://moveon.org/our-impact'>Our Impact</NavLink>
           </Primary.Section>
 

--- a/src/components/theme-giraffe/nav.js
+++ b/src/components/theme-giraffe/nav.js
@@ -30,7 +30,7 @@ const Nav = ({
             <NavLink href='https://moveon.org/browse-campaigns'>
               Browse Campaigns
             </NavLink>
-            <NavLink to='/campaign_tips.html'>Campaign Tips</NavLink>
+            <NavLink to='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
             <NavLink href='https://moveon.org/our-impact'>Our Impact</NavLink>
           </Primary.Section>
 


### PR DESCRIPTION
This actually points to the right place right now, but in case it changes in the future e.g. to a wordpress page that is easier to edit, this will use the proxy-configured link instead. Closes #491