### PR TITLE
Close the mobile menu when navigating internally

### DIFF
--- a/src/components/theme-giraffe/nav.js
+++ b/src/components/theme-giraffe/nav.js
@@ -13,51 +13,58 @@ const Nav = ({
   openSections,
   toggleSection,
   minimal
-}) => (
-  <Header toggleOpen={toggleOpen}>
-    <Logo />
-    {!minimal && (
-      <MoNav isOpenMobile={isOpenMobile} close={close}>
-        <Primary openSections={openSections} toggleSection={toggleSection}>
-          <Primary.Section name='Petitions'>
-            <NavLink to='/'>Browse Petitions</NavLink>
-            <NavLink to='/create_start.html?source=topnav'>
-              Start A Petition
-            </NavLink>
-            <NavLink to='/dashboard.html'>Manage Petitions</NavLink>
-          </Primary.Section>
+}) => {
+  // For closing the mobile menu when navigating internally
+  const InternalLink = props => <NavLink {...props} onClick={close} />
 
-          <Primary.Section name='Campaigns'>
-            <NavLink href='https://moveon.org/browse-campaigns'>
-              Browse Campaigns
-            </NavLink>
-            <NavLink href='https://moveon.org/campaign-tips'>Campaign Tips</NavLink>
-            <NavLink href='https://moveon.org/our-impact'>Our Impact</NavLink>
-          </Primary.Section>
+  return (
+    <Header toggleOpen={toggleOpen}>
+      <Logo />
+      {!minimal && (
+        <MoNav isOpenMobile={isOpenMobile} close={close}>
+          <Primary openSections={openSections} toggleSection={toggleSection}>
+            <Primary.Section name='Petitions'>
+              <InternalLink to='/'>Browse Petitions</InternalLink>
+              <InternalLink to='/create_start.html?source=topnav'>
+                Start A Petition
+              </InternalLink>
+              <InternalLink to='/dashboard.html'>Manage Petitions</InternalLink>
+            </Primary.Section>
 
-          {/* More Top level */}
-          <NavLink href='https://moveon.org/events'>Events</NavLink>
-          <NavLink href='https://front.moveon.org/about'>About Us</NavLink>
-        </Primary>
-        <Secondary>
-          <Secondary.Top>
-            <NavLink href='https://front.moveon.org/blog'>News</NavLink>
-            <NavLink href='https://store.moveon.org'>Store</NavLink>
-          </Secondary.Top>
-          <Secondary.Bottom>
-            <NavLink href='https://front.moveon.org/#join'>Join</NavLink>
-            <NavLink href='https://act.moveon.org/donate/civ-donation?utm_source=petitions_nav&source=petitions_nav'>
-              Donate
-            </NavLink>
-            <NavLink to='/create_start.html?source=topnav'>
-              <DocumentSvg />Start A Petition
-            </NavLink>
-          </Secondary.Bottom>
-        </Secondary>
-      </MoNav>
-    )}
-  </Header>
-)
+            <Primary.Section name='Campaigns'>
+              <NavLink href='https://moveon.org/browse-campaigns'>
+                Browse Campaigns
+              </NavLink>
+              <NavLink href='https://moveon.org/campaign-tips'>
+                Campaign Tips
+              </NavLink>
+              <NavLink href='https://moveon.org/our-impact'>Our Impact</NavLink>
+            </Primary.Section>
+
+            {/* More Top level */}
+            <NavLink href='https://moveon.org/events'>Events</NavLink>
+            <NavLink href='https://front.moveon.org/about'>About Us</NavLink>
+          </Primary>
+          <Secondary>
+            <Secondary.Top>
+              <NavLink href='https://front.moveon.org/blog'>News</NavLink>
+              <NavLink href='https://store.moveon.org'>Store</NavLink>
+            </Secondary.Top>
+            <Secondary.Bottom>
+              <NavLink href='https://front.moveon.org/#join'>Join</NavLink>
+              <NavLink href='https://act.moveon.org/donate/civ-donation?utm_source=petitions_nav&source=petitions_nav'>
+                Donate
+              </NavLink>
+              <InternalLink to='/create_start.html?source=topnav'>
+                <DocumentSvg />Start A Petition
+              </InternalLink>
+            </Secondary.Bottom>
+          </Secondary>
+        </MoNav>
+      )}
+    </Header>
+  )
+}
 
 Nav.propTypes = {
   user: PropTypes.object,

--- a/src/giraffe-ui/nav/navlink.js
+++ b/src/giraffe-ui/nav/navlink.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
-export const NavLink = ({ to, href, children }) => (
+export const NavLink = ({ to, href, children, onClick }) => (
   <li>
-    {to && <Link to={to}>{children}</Link>}
+    {to && <Link to={to} onClick={onClick}>{children}</Link>}
     {!to && href && <a href={href}>{children}</a>}
   </li>
 )
@@ -12,5 +12,6 @@ export const NavLink = ({ to, href, children }) => (
 NavLink.propTypes = {
   to: PropTypes.string,
   href: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  onClick: PropTypes.func
 }


### PR DESCRIPTION
By calling `close()` when `<Link>` is clicked.

fixes #503 

I looked into updating to react 16.3 so we could use Context for this (so NavLink components could read the context and call `close()` without being passed it directly), but the way we use enzyme was giving a lot of issues :(