### PR TITLE
Remove all references to petition 'slug' and replace with 'name'

### DIFF
--- a/docs/EXPLANATION--error-handling.md
+++ b/docs/EXPLANATION--error-handling.md
@@ -20,7 +20,7 @@ We also need to clear this error in the router's `onChange` callback, so if they
 
 When the user enters the app at certain special routes, e.g. the petition sign page, the django server provides the app with some data in `window.preloadObjects`. This saves the time of calling the extra `fetch()`.
 
-The user could load the app at a path that the django server recognizes, but some parameter (e.g. petition slug) could be incorrect, or there could be some other server-side issue that means that the server can't provide preload data.
+The user could load the app at a path that the django server recognizes, but some parameter (e.g. petition name) could be incorrect, or there could be some other server-side issue that means that the server can't provide preload data.
 
 In that case, the server will set `window.error` in the html body. We want to look for this on load and render based on it, so we check the error object in `actions/serverErrorActions.js:checkServerError()`, called on `componentDidMount` of Wrapper (so when the page loads). This function dispatches an action with the contents of any `window.error`, which causes the error to be set in `store.errorStore`.
 

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -33,15 +33,14 @@ export function loadPetition(petitionSlug, forceReload) {
     return dispatch => {
       dispatch({
         type: actionTypes.FETCH_PETITION_SUCCESS,
-        petition: window.preloadObjects[urlKey],
-        slug: petitionSlug
+        petition: window.preloadObjects[urlKey]
       })
     }
   }
   return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_PETITION_REQUEST,
-      slug: petitionSlug
+      name: petitionSlug
     })
     const { petitionStore } = getState()
     if (!forceReload
@@ -50,8 +49,7 @@ export function loadPetition(petitionSlug, forceReload) {
         && petitionStore.petitions[petitionSlug]) {
       return dispatch({
         type: actionTypes.FETCH_PETITION_SUCCESS,
-        petition: petitionStore.petitions[petitionSlug],
-        slug: petitionSlug
+        petition: petitionStore.petitions[petitionSlug]
       })
     }
     return fetch(`${Config.API_URI}/${urlKey}.json`)
@@ -60,15 +58,14 @@ export function loadPetition(petitionSlug, forceReload) {
       .then(json => {
         dispatch({
           type: actionTypes.FETCH_PETITION_SUCCESS,
-          petition: json,
-          slug: json.name || petitionSlug
+          petition: json
         })
       })
       .catch(err => {
         dispatch({
           type: actionTypes.FETCH_PETITION_FAILURE,
           error: err,
-          slug: petitionSlug
+          name: petitionSlug
         })
       })
   }
@@ -312,14 +309,14 @@ export const loadPetitionSignatures = (petition, page = 1) => {
   return dispatch => {
     dispatch({
       type: actionTypes.FETCH_PETITION_SIGNATURES_REQUEST,
-      slug: petitionSlug,
+      name: petitionSlug,
       page
     })
     const dispatchError = err => {
       dispatch({
         type: actionTypes.FETCH_PETITION_SIGNATURES_FAILURE,
         error: err,
-        slug: petitionSlug,
+        name: petitionSlug,
         page
       })
     }
@@ -329,7 +326,6 @@ export const loadPetitionSignatures = (petition, page = 1) => {
           dispatch({
             type: actionTypes.FETCH_PETITION_SIGNATURES_SUCCESS,
             signatures: json,
-            slug: petitionSlug,
             page
           })
         }, dispatchError),

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -27,6 +27,11 @@ export const actionTypes = {
   FEEDBACK_FAILURE: 'FEEDBACK_FAILURE'
 }
 
+/**
+ * Fetches a petition by name (slugified), and dispatches an action to place it in the store
+ * @param {string} petitionName A slugified version of the petition name, as returned by the api
+ * @param {boolean} forceReload Whether we should ignore petitions already in the redux store
+ */
 export function loadPetition(petitionName, forceReload) {
   const urlKey = `petitions/${petitionName}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {

--- a/src/actions/petitionActions.js
+++ b/src/actions/petitionActions.js
@@ -27,8 +27,8 @@ export const actionTypes = {
   FEEDBACK_FAILURE: 'FEEDBACK_FAILURE'
 }
 
-export function loadPetition(petitionSlug, forceReload) {
-  const urlKey = `petitions/${petitionSlug}`
+export function loadPetition(petitionName, forceReload) {
+  const urlKey = `petitions/${petitionName}`
   if (global && global.preloadObjects && global.preloadObjects[urlKey]) {
     return dispatch => {
       dispatch({
@@ -40,16 +40,16 @@ export function loadPetition(petitionSlug, forceReload) {
   return (dispatch, getState) => {
     dispatch({
       type: actionTypes.FETCH_PETITION_REQUEST,
-      name: petitionSlug
+      name: petitionName
     })
     const { petitionStore } = getState()
     if (!forceReload
         && petitionStore
         && petitionStore.petitions
-        && petitionStore.petitions[petitionSlug]) {
+        && petitionStore.petitions[petitionName]) {
       return dispatch({
         type: actionTypes.FETCH_PETITION_SUCCESS,
-        petition: petitionStore.petitions[petitionSlug]
+        petition: petitionStore.petitions[petitionName]
       })
     }
     return fetch(`${Config.API_URI}/${urlKey}.json`)
@@ -65,7 +65,7 @@ export function loadPetition(petitionSlug, forceReload) {
         dispatch({
           type: actionTypes.FETCH_PETITION_FAILURE,
           error: err,
-          name: petitionSlug
+          name: petitionName
         })
       })
   }
@@ -261,7 +261,7 @@ export function devLocalSignPetition(signature, petition, options) {
 
 function getPetitionListId(petition) {
   // Every petition has a couple of identifiers
-  // slug, petition_id, and also a list_id
+  // name, petition_id, and also a list_id
   // which is the object in the database that tracks the owner and signers
   // Since petition signatures are indexed against list_id, it's
   // more efficient to load through that value.
@@ -302,21 +302,21 @@ export const recordShareClick = (petition, tracking, medium, source, user) => {
 
 export const loadPetitionSignatures = (petition, page = 1) => {
   const petitionListId = getPetitionListId(petition)
-  const petitionSlug = petition.name
+  const petitionName = petition.name
   const urlKey = (petitionListId
                   ? `petitions/list${petitionListId}/signatures`
-                  : `petitions/${petitionSlug}/signatures`)
+                  : `petitions/${petitionName}/signatures`)
   return dispatch => {
     dispatch({
       type: actionTypes.FETCH_PETITION_SIGNATURES_REQUEST,
-      name: petitionSlug,
+      name: petitionName,
       page
     })
     const dispatchError = err => {
       dispatch({
         type: actionTypes.FETCH_PETITION_SIGNATURES_FAILURE,
         error: err,
-        name: petitionSlug,
+        name: petitionName,
         page
       })
     }

--- a/src/containers/cobrand-logo.js
+++ b/src/containers/cobrand-logo.js
@@ -46,8 +46,8 @@ const mapStateToProps = ({ navStore, petitionStore }, { params }) => {
   const orgName = params && params.organization
 
   // Will be present if we are viewing a petition
-  const petitionSlug = params && params.petition_slug
-  const petition = petitionSlug && petitionStore.petitions[petitionSlug.split('.')[0]]
+  const name = params && params.petitionName
+  const petition = name && petitionStore.petitions[name.split('.')[0]]
 
   if (orgName) {
     // check the url for an organization

--- a/src/containers/sign-petition.js
+++ b/src/containers/sign-petition.js
@@ -38,7 +38,7 @@ class SignPetition extends React.Component {
 
   componentWillMount() {
     const { dispatch, params, petition } = this.props
-    dispatch(petitionActions.loadPetition(params.petition_slug.split('.')[0]))
+    dispatch(petitionActions.loadPetition(params.petitionName.split('.')[0]))
     if (petition) {
       SignPetition.checkOrgPathMatches(petition, params.organization)
     }
@@ -148,7 +148,7 @@ SignPetition.propTypes = {
 }
 
 function mapStateToProps(store, ownProps) {
-  const petition = store.petitionStore.petitions[ownProps.params.petition_slug.split('.')[0]]
+  const petition = store.petitionStore.petitions[ownProps.params.petitionName.split('.')[0]]
   return {
     petition,
     sign_success:

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -54,9 +54,9 @@ Wrapper.propTypes = {
 }
 
 function mapStateToProps(store, ownProps) {
-  // Fetch the petition only if the route has a `petition_slug` param
-  const petitionSlug = ownProps.params && ownProps.params.petition_slug
-  const petition = petitionSlug && store.petitionStore.petitions[petitionSlug.split('.')[0]]
+  // Fetch the petition only if the route has a `petitionName` param
+  const name = ownProps.params && ownProps.params.petitionName
+  const petition = name && store.petitionStore.petitions[name.split('.')[0]]
 
   return {
     petitionEntity: petition && petition.entity,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -185,3 +185,5 @@ export const parseSQSApiResponse = response =>
       })
     }
   })
+
+export const byIdAndName = p => ({ [p.petition_id]: p, [p.name]: p })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,8 +10,8 @@ import errorReducer from './error'
 import staticPageReducer from './static-pages'
 
 const initialPetitionState = {
-  petitions: {}, // Keyed by name AND petition_id for petition route
-  petitionSignatures: {}, // Keyed by petition name, then page
+  petitions: {}, // Keyed by name (slug) AND petition_id for petition route
+  petitionSignatures: {}, // Keyed by petition name (slug), then page
   signatureStatus: {}, // Keyed by petition_id (because form doesn't have name)
   signatureMessages: {}, // Keyed by petition_id, MessageId value from SQS post
   topPetitions: {}, // Lists of petition IDs keyed by pac then megapartner
@@ -67,7 +67,7 @@ function petitionReducer(state = initialPetitionState, action) {
         ...state,
         petitions: {
           ...state.petitions,
-          // Key it both by id and by name, for different lookup needs
+          // Key it both by id and by name (slug), for different lookup needs
           ...byIdAndName(petition)
         }
       }
@@ -99,7 +99,7 @@ function petitionReducer(state = initialPetitionState, action) {
         ...state,
         petitionSignatures: {
           ...state.petitionSignatures,
-          [petition.name]: {
+          [petition.name]: { // slug
             ...state.petitionSignatures[petition.name],
             [page]: signatures._embedded.map(signature =>
               Object.assign(signature, { user: signature._embedded.user })

--- a/src/routes.js
+++ b/src/routes.js
@@ -91,8 +91,8 @@ export const routes = store => {
       <IndexRoute prodReady component={LoadableHome} />
 
       {/* Sign pages are popular entry pages, so they get included in the main bundle (not Loadable) */}
-      <Route path='sign/:petition_slug' component={Sign} prodReady />
-      <Route path=':organization/sign/:petition_slug' component={Sign} onEnter={orgLoader} prodReady />
+      <Route path='sign/:petitionName' component={Sign} prodReady />
+      <Route path=':organization/sign/:petitionName' component={Sign} onEnter={orgLoader} prodReady />
 
       <Route path='pac/' component={LoadablePacHome} prodReady />
       <Route path='thanks.html' component={ThanksShim} prodReady minimalNav />

--- a/src/routes.js
+++ b/src/routes.js
@@ -90,7 +90,9 @@ export const routes = store => {
     <Route path={baseAppPath} component={Wrapper} onChange={onChange}>
       <IndexRoute prodReady component={LoadableHome} />
 
-      {/* Sign pages are popular entry pages, so they get included in the main bundle (not Loadable) */}
+      {/* Sign pages are popular entry pages, so they get included in the main bundle (not Loadable)
+          petitionName is a slugified name, matching the slugified "name" returned by the api.
+      */}
       <Route path='sign/:petitionName' component={Sign} prodReady />
       <Route path=':organization/sign/:petitionName' component={Sign} onEnter={orgLoader} prodReady />
 

--- a/test/components/cobrand-logo.js
+++ b/test/components/cobrand-logo.js
@@ -6,16 +6,16 @@ import { createMockStore } from 'redux-test-utils'
 import CobrandLogo from '../../src/containers/cobrand-logo'
 
 function getParams({ embed, org }) {
-  const petitionSlug = 'test'
+  const petitionName = 'test'
   const orgSlug = 'test-org'
   const store = {}
   const params = {}
   if (embed) {
     store.petitionStore = {
-      petitions: { [petitionSlug]: { _embedded: embed } }
+      petitions: { [petitionName]: { _embedded: embed } }
     }
 
-    params.petition_slug = petitionSlug
+    params.petitionName = petitionName
   }
 
   if (org) {

--- a/test/store/petition-load.js
+++ b/test/store/petition-load.js
@@ -33,10 +33,8 @@ describe('Petition loading', () => {
 
   it('creates FETCH_PETITION_SUCCESS when loading petition', done => {
     const expectedActions = [
-      { type: actionTypes.FETCH_PETITION_REQUEST, slug: 'outkast' },
-      { type: actionTypes.FETCH_PETITION_SUCCESS,
-        slug: 'outkast',
-        petition: samplePetition }
+      { type: actionTypes.FETCH_PETITION_REQUEST, name: 'outkast' },
+      { type: actionTypes.FETCH_PETITION_SUCCESS, petition: samplePetition }
     ]
     const store = mockStore()
     expectAsync(store.dispatch(loadPetition('outkast')),


### PR DESCRIPTION
fixes #485 

As a follow up to https://github.com/MoveOnOrg/mop-frontend/pull/484, where we made nothing depend on petition.slug, I figured it would be good to remove it from the store.

I also changed all references from "slug" to "name" as, in my opinion, it's better to match what is returned from the API, even if the name isn't perfect.