### PR TITLE
Refactor target select

### DIFF
--- a/local/api/v1/targets.json
+++ b/local/api/v1/targets.json
@@ -1,37 +1,72 @@
 [
-{
-  "label": "Sen. Brian Schatz (HI-1)",
-  "name": "Sen. Brian Schatz (HI-1)",
-  "value": "senatemem:HI_1:Sen. Brian Schatz (HI-1)"
-},
-{
-  "label": "Sen. Mazie Hirono (HI-2)",
-  "name": "Sen. Mazie Hirono (HI-2)",
-  "value": "senatemem:HI_2:Sen. Mazie Hirono (HI-2)"
-},
-{
-  "label": "Sen. Charles Grassley (IA-1)",
-  "name": "Sen. Charles Grassley (IA-1)",
-  "value": "senatemem:IA_1:Sen. Charles Grassley (IA-1)"
-},
-{
-  "label": "Sen. Joni Ernst (IA-2)",
-  "name": "Sen. Joni Ernst (IA-2)",
-  "value": "senatemem:IA_2:Sen. Joni Ernst (IA-2)"
-},
-{
-  "label": "Sen. Michael Crapo (ID-1)",
-  "name": "Sen. Michael Crapo (ID-1)",
-  "value": "senatemem:ID_1:Sen. Michael Crapo (ID-1)"
-},
-{
-  "label": "Sen. James Risch (ID-2)",
-  "name": "Sen. James Risch (ID-2)",
-  "value": "senatemem:ID_2:Sen. James Risch (ID-2)"
-},
-{
-  "label": "Sen. Richard Durbin (IL-1)",
-  "name": "Sen. Richard Durbin (IL-1)",
-  "value": "senatemem:IL_1:Sen. Richard Durbin (IL-1)"
-}
+  {
+    "label": "Donald Trump",
+    "name": "Donald Trump",
+    "value": "president::Donald Trump",
+    "target_type": "president",
+    "target_id": ""
+    },
+    {
+      "label": "The United States House of Representatives",
+      "name": "The United States House of Representatives",
+      "value": "house::The United States House of Representatives",
+      "target_type": "house",
+      "target_id": ""
+    },
+    {
+      "label": "The United States Senate",
+      "name": "The United States Senate",
+      "value": "senate::The United States Senate",
+      "target_type": "senate",
+      "target_id": ""
+    },
+    {
+      "label": "Sen. Brian Schatz (HI-1)",
+      "name": "Sen. Brian Schatz (HI-1)",
+      "value": "senatemem:HI_1:Sen. Brian Schatz (HI-1)",
+      "target_type": "senatemem",
+      "target_id": "HI_1"
+    },
+    {
+      "label": "Sen. Mazie Hirono (HI-2)",
+      "name": "Sen. Mazie Hirono (HI-2)",
+      "value": "senatemem:HI_2:Sen. Mazie Hirono (HI-2)",
+      "target_type": "senatemem",
+      "target_id": "HI_2"
+    },
+    {
+      "label": "Sen. Charles Grassley (IA-1)",
+      "name": "Sen. Charles Grassley (IA-1)",
+      "value": "senatemem:IA_1:Sen. Charles Grassley (IA-1)",
+      "target_type": "senatemem",
+      "target_id": "IA_1"
+    },
+    {
+      "label": "Sen. Joni Ernst (IA-2)",
+      "name": "Sen. Joni Ernst (IA-2)",
+      "value": "senatemem:IA_2:Sen. Joni Ernst (IA-2)",
+      "target_type": "senatemem",
+      "target_id": "IA_2"
+    },
+    {
+      "label": "Sen. Michael Crapo (ID-1)",
+      "name": "Sen. Michael Crapo (ID-1)",
+      "value": "senatemem:ID_1:Sen. Michael Crapo (ID-1)",
+      "target_type": "senatemem",
+      "target_id": "ID_1"
+    },
+    {
+      "label": "Sen. James Risch (ID-2)",
+      "name": "Sen. James Risch (ID-2)",
+      "value": "senatemem:ID_2:Sen. James Risch (ID-2)",
+      "target_type": "senatemem",
+      "target_id": "ID_2"
+    },
+    {
+      "label": "Sen. Richard Durbin (IL-1)",
+      "name": "Sen. Richard Durbin (IL-1)",
+      "value": "senatemem:IL_1:Sen. Richard Durbin (IL-1)",
+      "target_type": "senatemem",
+      "target_id": "IL_1"
+    }
 ]

--- a/src/components/theme-legacy/create-petition-form.js
+++ b/src/components/theme-legacy/create-petition-form.js
@@ -25,9 +25,14 @@ const CreatePetitionForm = ({
   instructionStyle,
   setRef,
   errors,
-  getValue,
   onChange,
-  onPreview
+  onPreview,
+  title,
+  summary,
+  description,
+  targets,
+  onTargetAdd,
+  onTargetRemove
 }) => {
   const instructions = instructionsByField[selected]
 
@@ -59,7 +64,7 @@ const CreatePetitionForm = ({
                   type='text'
                   title='Your Petition Title'
                   placeholder='Petition title'
-                  value={getValue('title')}
+                  value={title}
                   onChange={onChange}
                   onClick={setSelected('title')}
                   ref={setRef('titleInput')}
@@ -72,7 +77,7 @@ const CreatePetitionForm = ({
                   placeholder='What&rsquo;s the text of your petition? (Try to keep it to 1-2 sentences.)'
                   id='text_statement_field'
                   title='Text of your Petition'
-                  value={getValue('summary')}
+                  value={summary}
                   onChange={onChange}
                   onClick={setSelected('statement')}
                   ref={setRef('statementInput')}
@@ -82,7 +87,9 @@ const CreatePetitionForm = ({
             <CreatePetitionTarget
               setSelected={setSelected}
               setRef={setRef}
-              onChange={onChange}
+              targets={targets}
+              onTargetAdd={onTargetAdd}
+              onTargetRemove={onTargetRemove}
             />
             <fieldset id='statement'>
               <span className='circle-number'>3</span>
@@ -96,7 +103,7 @@ const CreatePetitionForm = ({
                   id='text_about_field'
                   placeholder='What&rsquo;s your petition about? Have you been personally affected by the issue?'
                   title='Petition Background'
-                  value={getValue('description')}
+                  value={description}
                   onChange={onChange}
                   onClick={setSelected('about')}
                   ref={setRef('aboutInput')}
@@ -132,9 +139,14 @@ CreatePetitionForm.propTypes = {
   instructionStyle: PropTypes.object,
   setRef: PropTypes.func,
   errors: PropTypes.array.isRequired,
-  getValue: PropTypes.func,
   onChange: PropTypes.func,
-  onPreview: PropTypes.func
+  onPreview: PropTypes.func,
+  title: PropTypes.string,
+  summary: PropTypes.string,
+  description: PropTypes.string,
+  targets: PropTypes.array,
+  onTargetAdd: PropTypes.func,
+  onTargetRemove: PropTypes.func
 }
 
 export default CreatePetitionForm

--- a/src/components/theme-legacy/form/target-select/custom.js
+++ b/src/components/theme-legacy/form/target-select/custom.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 const CustomTargetSelect = ({
   selected,
+  remove,
   onSelect,
   customInputs,
   onChangeInputs
@@ -15,13 +16,8 @@ const CustomTargetSelect = ({
           <label className='target_label'>
             <input
               type='checkbox'
-              checked={target.checked}
-              onChange={() =>
-                onSelect({
-                  ...target,
-                  checked: !target.checked
-                })
-              }
+              checked
+              onChange={() => remove(target)}
             />{' '}
             {target.name +
               (target.title && `, ${target.title}`) +
@@ -67,7 +63,6 @@ const CustomTargetSelect = ({
           onClick={() => {
             onSelect({
               target_type: 'custom',
-              checked: true,
               ...customInputs
             })
           }}
@@ -83,6 +78,7 @@ const CustomTargetSelect = ({
 
 CustomTargetSelect.propTypes = {
   selected: PropTypes.array.isRequired,
+  remove: PropTypes.func,
   onSelect: PropTypes.func,
   customInputs: PropTypes.object,
   onChangeInputs: PropTypes.func

--- a/src/components/theme-legacy/form/target-select/index.js
+++ b/src/components/theme-legacy/form/target-select/index.js
@@ -7,7 +7,10 @@ export const TargetForm = ({
   setRef,
   renderNational,
   renderGeoState,
-  renderCustom
+  renderCustom,
+  nationalOpen,
+  stateOpen,
+  customOpen
 }) => (
   <div id='target_wrapper' className='' title='Choosing a Target'>
     <fieldset id='target' className=''>
@@ -27,8 +30,9 @@ export const TargetForm = ({
             id='national_group'
             type='checkbox'
             className='reveal_more_options'
-            onClick={toggleOpen('nationalOpen')}
+            onChange={toggleOpen('nationalOpen')}
             ref={setRef('nationalInput')}
+            checked={nationalOpen}
           />{' '}
           The White House or Congress
         </label>
@@ -46,8 +50,9 @@ export const TargetForm = ({
             id='state_group'
             type='checkbox'
             className='reveal_more_options'
-            onClick={toggleOpen('stateOpen')}
+            onChange={toggleOpen('stateOpen')}
             ref={setRef('stateInput')}
+            checked={stateOpen}
           />{' '}
           Your governor or state legislature
         </label>
@@ -64,8 +69,9 @@ export const TargetForm = ({
             id='custom_group'
             type='checkbox'
             className='reveal_more_options'
-            onClick={toggleOpen('customOpen')}
+            onChange={toggleOpen('customOpen')}
             ref={setRef('customInput')}
+            checked={customOpen}
           />{' '}
           Someone else (like a local official or corporate CEO)
         </label>
@@ -81,5 +87,8 @@ TargetForm.propTypes = {
   setRef: PropTypes.func,
   renderNational: PropTypes.func,
   renderGeoState: PropTypes.func,
-  renderCustom: PropTypes.func
+  renderCustom: PropTypes.func,
+  nationalOpen: PropTypes.bool,
+  stateOpen: PropTypes.bool,
+  customOpen: PropTypes.bool
 }

--- a/src/components/theme-legacy/form/target-select/legislator-autocomplete.js
+++ b/src/components/theme-legacy/form/target-select/legislator-autocomplete.js
@@ -40,7 +40,7 @@ export const LegislatorAutocomplete = ({ onChange, group, state, items }) => (
   <Downshift
     onChange={(item, actions) => {
       actions.clearSelection()
-      onChange({ ...item, checked: true })
+      onChange(item)
     }}
     itemToString={item => (item ? item.name : '')}
     render={({

--- a/src/components/theme-legacy/form/target-select/national.js
+++ b/src/components/theme-legacy/form/target-select/national.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import LegislatorAutocomplete from './legislator-autocomplete'
 
-const NationalTargetSelect = ({ selected, onSelect, items }) => (
+const NationalTargetSelect = ({ selected, onSelect, remove, items }) => (
   <div>
     <div id='national_group_checkboxes'>
       {selected.map(selectedItem => (
@@ -11,10 +11,8 @@ const NationalTargetSelect = ({ selected, onSelect, items }) => (
           <label>
             <input
               type='checkbox'
-              onChange={() =>
-                onSelect({ ...selectedItem, checked: !selectedItem.checked })
-              }
-              checked={selectedItem.checked}
+              onChange={() => remove(selectedItem)}
+              checked
             />{' '}
             {selectedItem.label}
           </label>
@@ -41,6 +39,7 @@ function mapStateToProps(store) {
 NationalTargetSelect.propTypes = {
   selected: PropTypes.array,
   onSelect: PropTypes.func,
+  remove: PropTypes.func,
   items: PropTypes.array
 }
 

--- a/src/components/theme-legacy/form/target-select/national.js
+++ b/src/components/theme-legacy/form/target-select/national.js
@@ -3,10 +3,31 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import LegislatorAutocomplete from './legislator-autocomplete'
 
+const isDefault = target =>
+  ['president', 'house', 'senate'].indexOf(target.target_type) !== -1
+
 const NationalTargetSelect = ({ selected, onSelect, remove, items }) => (
   <div>
     <div id='national_group_checkboxes'>
-      {selected.map(selectedItem => (
+      {items.filter(isDefault).map(defaultItem => {
+        const isChecked = selected.filter(t => t.value === defaultItem.value)
+          .length
+        return (
+          <div key={defaultItem.label} className='checkbox wrapper'>
+            <label>
+              <input
+                type='checkbox'
+                onChange={() =>
+                  (isChecked ? remove(defaultItem) : onSelect(defaultItem))
+                }
+                checked={isChecked}
+              />{' '}
+              {defaultItem.label}
+            </label>
+          </div>
+        )
+      })}
+      {selected.filter(t => !isDefault(t)).map(selectedItem => (
         <div key={selectedItem.label} className='checkbox wrapper'>
           <label>
             <input
@@ -23,7 +44,7 @@ const NationalTargetSelect = ({ selected, onSelect, remove, items }) => (
       <LegislatorAutocomplete
         group='national'
         onChange={onSelect}
-        items={items}
+        items={items.filter(t => !isDefault(t))}
       />
     </div>
   </div>

--- a/src/components/theme-legacy/form/target-select/state.js
+++ b/src/components/theme-legacy/form/target-select/state.js
@@ -7,6 +7,7 @@ import StateSelect from '../state-select'
 
 const StateTargetSelect = ({
   selected,
+  remove,
   onSelect,
   geoState,
   onChangeGeoState,
@@ -30,13 +31,8 @@ const StateTargetSelect = ({
           <label>
             <input
               type='checkbox'
-              onChange={() =>
-                onSelect({
-                  ...selectedItem,
-                  checked: !selectedItem.checked
-                })
-              }
-              checked={selectedItem.checked}
+              onChange={() => remove(selectedItem)}
+              checked
             />{' '}
             {selectedItem.label}
           </label>
@@ -68,6 +64,7 @@ function mapStateToProps(store, ownProps) {
 
 StateTargetSelect.propTypes = {
   selected: PropTypes.array,
+  remove: PropTypes.func,
   onSelect: PropTypes.func,
   autocompleteItems: PropTypes.array,
   geoState: PropTypes.string,

--- a/src/components/theme-legacy/form/target-select/state.js
+++ b/src/components/theme-legacy/form/target-select/state.js
@@ -5,6 +5,9 @@ import { connect } from 'react-redux'
 import LegislatorAutocomplete from './legislator-autocomplete'
 import StateSelect from '../state-select'
 
+const isDefault = target =>
+  ['governor', 'statehouse', 'statesenate'].indexOf(target.target_type) !== -1
+
 const StateTargetSelect = ({
   selected,
   remove,
@@ -26,7 +29,28 @@ const StateTargetSelect = ({
       />
     </div>
     <div id='state_group_checkboxes'>
-      {selected.map(selectedItem => (
+      {autocompleteItems.filter(isDefault).map(defaultItem => {
+        const isChecked = selected.filter(
+          t =>
+            t.target_type === defaultItem.target_type &&
+            t.target_id === defaultItem.target_id
+        ).length
+        return (
+          <div key={defaultItem.label} className='checkbox wrapper'>
+            <label>
+              <input
+                type='checkbox'
+                onChange={() =>
+                  (isChecked ? remove(defaultItem) : onSelect(defaultItem))
+                }
+                checked={isChecked}
+              />{' '}
+              {defaultItem.label}
+            </label>
+          </div>
+        )
+      })}
+      {selected.filter(t => !isDefault(t)).map(selectedItem => (
         <div key={selectedItem.label} className='checkbox wrapper'>
           <label>
             <input
@@ -39,17 +63,14 @@ const StateTargetSelect = ({
         </div>
       ))}
     </div>
-    <div
-      id='state_group_autocomplete_wrapper'
-      className='autocomplete_wrapper text wrapper small'
-    >
-      {geoState && (
+    <div className='autocomplete_wrapper text wrapper small'>
+      {geoState &&
         <LegislatorAutocomplete
           group='national'
           onChange={onSelect}
-          items={autocompleteItems}
+          items={autocompleteItems.filter(t => !isDefault(t))}
         />
-      )}
+      }
     </div>
   </div>
 )

--- a/src/containers/create-petition-target.js
+++ b/src/containers/create-petition-target.js
@@ -3,66 +3,59 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import { loadTargets } from '../actions/createPetitionActions'
-import { getStateFullName } from '../lib'
 
 import { TargetForm } from 'LegacyTheme/form/target-select'
 import NationalTargetSelect from 'LegacyTheme/form/target-select/national'
 import StateTargetSelect from 'LegacyTheme/form/target-select/state'
 import CustomTargetSelect from '../components/theme-legacy/form/target-select/custom'
 
-const NATIONAL = [
-  {
-    label: 'The entire U.S. House',
-    default: true,
-    checked: false
-  },
-  {
-    label: 'The entire U.S. Senate',
-    default: true,
-    checked: false
-  },
-  {
-    label: 'President Donald Trump',
-    default: true,
-    checked: false
-  }
-]
-
-const STATE = [
-  {
-    label: 'The entire __STATE__ House',
-    default: true,
-    checked: false
-  },
-  {
-    label: 'The entire __STATE__ Senate',
-    default: true,
-    checked: false
-  },
-  {
-    label: 'Governor of __STATE__',
-    default: true,
-    checked: false
-  }
-]
-
 export class CreatePetitionTarget extends React.Component {
+  static getDerivedStateFromProps(props) {
+    const customTargets = props.targets.filter(t => t.target_type === 'custom')
+    const nationalTargets = props.targets.filter(
+      target =>
+        ['senatemem', 'housemem', 'president', 'house', 'senate'].indexOf(
+          target.target_type
+        ) !== -1
+    )
+    const stateTargets = props.targets.filter(
+      target =>
+        [
+          'statesenatemem',
+          'statehousemem',
+          'governor',
+          'statehouse',
+          'statesenate'
+        ].indexOf(target.target_type) !== -1
+    )
+
+    const openCheckboxes = {}
+    if (nationalTargets.length) openCheckboxes.nationalOpen = true
+    if (stateTargets.length) {
+      openCheckboxes.stateOpen = true
+      openCheckboxes.geoState = stateTargets[0].target_id
+    }
+    if (customTargets.length) openCheckboxes.customOpen = true
+
+    return {
+      nationalTargets,
+      stateTargets,
+      customTargets,
+      ...openCheckboxes
+    }
+  }
+
   constructor(props) {
     super(props)
     this.state = {
       nationalOpen: false,
+      geoState: null,
       stateOpen: false,
       customOpen: false,
-      national: NATIONAL,
-      geoState: null,
-      geoStateSelected: [],
-      customInputs: { name: '', email: '', title: '' },
-      customSelected: []
+      customInputs: { name: '', email: '', title: '' }
     }
 
     this.toggleOpen = this.toggleOpen.bind(this)
-    this.onSelect = this.onSelect.bind(this)
-    this.getAllCheckedTargets = this.getAllCheckedTargets.bind(this)
     this.renderNational = this.renderNational.bind(this)
     this.renderGeoState = this.renderGeoState.bind(this)
     this.renderCustom = this.renderCustom.bind(this)
@@ -71,48 +64,13 @@ export class CreatePetitionTarget extends React.Component {
   componentDidMount() {
     // Preload congress for autocomplete
     this.props.dispatch(loadTargets('national'))
-  }
 
-  onSelect(group) {
-    return target => {
-      if (!target.label && !(target.target_type === 'custom' && target.name)) {
-        // target is invalid
-        return
-      }
-
-      this.setState(
-        state => {
-          const newGroup = [...state[group]]
-          // Try to up the existing index by label or name (custom)
-          const existing = target.label
-            ? newGroup.findIndex(old => old.label === target.label)
-            : newGroup.findIndex(old => old.name === target.name)
-
-          if (existing === -1) {
-            newGroup.push(target) // Add it if the target isn't in the list
-          } else {
-            // Else replace the target with new data ("checked" may have changed)
-            newGroup[existing] = target
-          }
-          return { [group]: newGroup }
-        },
-        () =>
-          this.props.onChange({
-            target: {
-              name: 'target',
-              value: this.getAllCheckedTargets()
-            }
-          })
-        )
+    // Handle if we need to preload a geoState
+    if (this.state.stateTargets && this.state.stateTargets.length) {
+      this.props.dispatch(
+        loadTargets('state', this.state.stateTargets[0].target_id)
+      )
     }
-  }
-
-  getAllCheckedTargets() {
-    const groups = [this.state.national, this.state.geoStateSelected, this.state.customSelected]
-    return groups.reduce(
-      (acc, group) => [...acc, ...group.filter(obj => obj.checked)],
-      []
-    )
   }
 
   toggleOpen(key) {
@@ -120,54 +78,46 @@ export class CreatePetitionTarget extends React.Component {
   }
 
   renderNational() {
-    const { nationalOpen, national } = this.state
-    if (!nationalOpen) return null
+    if (!this.state.nationalOpen) return null
     return (
       <NationalTargetSelect
-        selected={national}
-        onSelect={this.onSelect('national')}
+        selected={this.state.nationalTargets}
+        remove={this.props.onTargetRemove}
+        onSelect={this.props.onTargetAdd}
       />
     )
   }
 
   renderGeoState() {
-    const { stateOpen, geoState, geoStateSelected } = this.state
-    const { dispatch } = this.props
-    const self = this
-    if (!stateOpen) return null
+    if (!this.state.stateOpen) return null
     return (
       <StateTargetSelect
-        selected={geoStateSelected}
-        onSelect={this.onSelect('geoStateSelected')}
-        geoState={geoState}
+        geoState={this.state.geoState}
+        selected={this.state.stateTargets}
+        remove={this.props.onTargetRemove}
+        onSelect={this.props.onTargetAdd}
         onChangeGeoState={event => {
           const { value } = event.target
-          dispatch(loadTargets('state', value))
-          self.setState({
-            geoState: value,
-            geoStateSelected: STATE.map(obj => ({
-              ...obj,
-              label: obj.label.replace('__STATE__', getStateFullName(value))
-            }))
-          })
+          this.props.dispatch(loadTargets('state', value))
+          this.setState({ geoState: value })
         }}
       />
     )
   }
 
   renderCustom() {
-    const { customOpen, customInputs, customSelected } = this.state
+    const { customOpen, customInputs } = this.state
     if (!customOpen) return null
     return (
       <CustomTargetSelect
-        selected={customSelected}
+        selected={this.state.customTargets}
+        remove={this.props.onTargetRemove}
         onSelect={target => {
-          this.onSelect('customSelected')(target)
+          this.props.onTargetAdd(target, { isCustom: true })
           this.setState({ customInputs: { name: '', email: '', title: '' } })
         }}
         customInputs={customInputs}
-        onChangeInputs={event => {
-          const { name, value } = event.target
+        onChangeInputs={({ target: { name, value } }) => {
           this.setState(state => ({
             customInputs: { ...state.customInputs, [name]: value }
           }))
@@ -187,6 +137,9 @@ export class CreatePetitionTarget extends React.Component {
         renderGeoState={this.renderGeoState}
         renderCustom={this.renderCustom}
         toggleOpen={this.toggleOpen}
+        nationalOpen={this.state.nationalOpen}
+        stateOpen={this.state.stateOpen}
+        customOpen={this.state.customOpen}
       />
     )
   }
@@ -195,8 +148,11 @@ export class CreatePetitionTarget extends React.Component {
 CreatePetitionTarget.propTypes = {
   setSelected: PropTypes.func,
   setRef: PropTypes.func,
-  onChange: PropTypes.func,
-  dispatch: PropTypes.func
+  onTargetAdd: PropTypes.func,
+  onTargetRemove: PropTypes.func,
+  dispatch: PropTypes.func,
+  // eslint-disable-next-line
+  targets: PropTypes.array
 }
 
 export default connect()(CreatePetitionTarget)

--- a/src/reducers/petition-targets.js
+++ b/src/reducers/petition-targets.js
@@ -1,9 +1,44 @@
 import { actionTypes } from '../actions/createPetitionActions'
+import { getStateFullName } from '../lib'
+
+// These will be added to the store as soon as the state is selected
+// so the user doesn't have to wait for the target request to complete
+// to see some default values.
+const addStateInitialValues = geoState => [
+  {
+    label: `The entire ${getStateFullName(geoState)} Senate`,
+    target_type: 'statesenate',
+    target_id: geoState
+  },
+  {
+    label: `The entire ${getStateFullName(geoState)} House`,
+    target_type: 'statehouse',
+    target_id: geoState
+  },
+  {
+    label: `Govenor of ${getStateFullName(geoState)}`,
+    target_type: 'governor',
+    target_id: geoState
+  }
+]
 
 const reducer = (state = {}, action) => {
   switch (action.type) {
+    case actionTypes.FETCH_TARGETS_REQUEST:
+      if (action.group === 'national') return { ...state, national: [] }
+      else if (action.group === 'state') {
+        return {
+          ...state,
+          [`state--${action.geoState}`]: addStateInitialValues(action.geoState)
+        }
+      }
+      return state
+
     case actionTypes.FETCH_TARGETS_SUCCESS:
-      return { ...state, [action.storeKey]: action.targets }
+      return {
+        ...state,
+        [action.storeKey]: [...state[action.storeKey] || [], ...action.targets]
+      }
     default:
       return state
   }

--- a/test/components/create-petition-target.js
+++ b/test/components/create-petition-target.js
@@ -1,50 +1,60 @@
 import React from 'react'
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
+import { createMockStore } from 'redux-test-utils'
+import { mount } from 'enzyme'
 
-import {
-  CreatePetitionTarget as CreatePetitionTargetUnwrapped
-} from '../../src/containers/create-petition-target'
+import CreatePetitionTarget from '../../src/containers/create-petition-target'
+import targets from '../../local/api/v1/targets.json'
 
 describe('<CreatePetitionTarget />', () => {
-  it('adds petition targets to the state when selected, and fires onChange', () => {
+  const store = createMockStore({ petitionTargetsStore: { national: targets } })
+  it('calls onTargetAdd when an option is clicked', () => {
     const onChange = sinon.spy()
-    const component = shallow(
-      <CreatePetitionTargetUnwrapped onChange={onChange} dispatch={() => {}} />
+    const component = mount(
+      <Provider store={store}>
+        <CreatePetitionTarget
+          setSelected={() => {}}
+          setRef={() => {}}
+          targets={[]}
+          onTargetAdd={onChange}
+        />
+      </Provider>
     )
-    const selectNational = component.instance().onSelect('national')
-    const senator = {
-      label: 'Senator Someone',
-      value: 'senator:blah',
-      checked: true
-    }
-    selectNational(senator)
-    expect(component.state('national')).to.include(senator)
-    expect(
-      onChange.calledWith({
-        target: { name: 'target', value: [senator] }
-      })
-    ).to.be.true
+    // Open the national target group
+    component
+      .find('input[name="checkbox_national_group"]')
+      .simulate('change', { target: { checked: true } })
+
+    // Click the first item (Donald Trump)
+    component
+      .find('#national_group_checkboxes input[type="checkbox"]')
+      .first()
+      .simulate('change', { target: { checked: true } })
+
+    expect(onChange.firstCall.args[0]).to.equal(targets[0])
   })
 
-  it('modifies existing petition targets to the state when selected, and fires onChange', () => {
+  it('calls remove when a selected option is clicked', () => {
     const onChange = sinon.spy()
-    const component = shallow(
-      <CreatePetitionTargetUnwrapped onChange={onChange} dispatch={() => {}} />
+    const component = mount(
+      <Provider store={store}>
+        <CreatePetitionTarget
+          targets={[targets[0]]} // Donald Trump already selected
+          setSelected={() => {}}
+          setRef={() => {}}
+          onTargetRemove={onChange}
+        />
+      </Provider>
     )
-    const selectNational = component.instance().onSelect('national')
-    const target = {
-      label: 'The entire U.S. House',
-      checked: true
-    }
-    selectNational(target)
-    expect(component.state('national').length).to.equal(3)
-    expect(component.state('national')).to.include(target)
-    expect(
-      onChange.calledWith({
-        target: { name: 'target', value: [target] }
-      })
-    ).to.be.true
+
+    // Click the first item (Donald Trump)
+    component
+      .find('#national_group_checkboxes input[type="checkbox"]')
+      .first()
+      .simulate('change', { target: { checked: false } })
+
+    expect(onChange.firstCall.args[0]).to.equal(targets[0])
   })
 })

--- a/test/components/create-petition.js
+++ b/test/components/create-petition.js
@@ -52,7 +52,7 @@ describe('<CreatePetition />', () => {
   })
 
   forEach([
-    ['national', 'The entire U.S. House'],
+    ['national', 'Or, enter a specific legislator'],
     ['state', 'Pick your state'],
     ['custom', 'Add another target']
   ]).it('Clicking %s checkbox shows hidden content', (name, text) => {
@@ -61,8 +61,8 @@ describe('<CreatePetition />', () => {
         <CreatePetition />
       </Provider>
     )
-    context.find(`input[name="checkbox_${name}_group"]`).simulate('click')
-    expect(context.find('#target_wrapper').text()).to.contain(text)
+    context.find(`input[name="checkbox_${name}_group"]`).simulate('change', { target: { checked: true } })
+    expect(context.find('#target_wrapper').html()).to.contain(text)
   })
 
   it('typing incomplete fields submit fails and displays validation error messages', () => {
@@ -78,12 +78,7 @@ describe('<CreatePetition />', () => {
   it('has errors when required fields are missing', () => {
     const component = shallow(<CreatePetitionUnwrapped />)
 
-    component.instance().onInputChange({
-      target: {
-        name: 'title',
-        value: 'test'
-      }
-    })
+    component.instance().setState({ title: 'test' })
     component.instance().onPreview({ preventDefault: () => {} })
     expect(component.state('errors').length).to.equal(3)
   })
@@ -97,9 +92,7 @@ describe('<CreatePetition />', () => {
       summary: 'testsummary',
       description: 'testdescription'
     }
-    component.setState({
-      data: petition
-    })
+    component.setState(petition)
     component.instance().onPreview({ preventDefault: () => {} })
     expect(dispatch.calledOnce).to.be.true
   })


### PR DESCRIPTION
To support /petition_revise.html, plus a cleaner way of doing it overall, an initialPetition can be passed to CreatePetition and the petition targets are analyzed as to whether they are national, state, or custom in CreatePetitionTargets in order to set the right state for the petition target checkboxes and such.

The national and state target forms know if the targets are "default" (shown as a checkbox) or otherwise pass them to the autocomplete component. It also handles showing any already selected targets as pre-checked checkboxes.

Note that this will be merged into the create-petitions branch.

This one still just submits the petition into the redux state. I'll open other PRs that add previewing, revising, and submitting to the API. It should be fine to merge this to `main` for testing though :)

Related issues:
- [ ] https://github.com/MoveOnOrg/mop/issues/404