### PR TITLE
Preview petition

### DIFF
--- a/src/components/theme-legacy/create-preview.js
+++ b/src/components/theme-legacy/create-preview.js
@@ -1,0 +1,107 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import RegisterForm from '../../containers/register-form'
+
+const getTargets = target => target.map(t => t.label || t.name).join(', ')
+
+export const CreatePreview = ({ petition, user, onSubmit }) => (
+  <div className='container background-moveon-white bump-top-1'>
+    <div className='container background-moveon-white bump-top-1'>
+      <div className='row'>
+        <div className='span4 widget clearfix background-moveon-light-gray'>
+          <h3 className='widget-top-fancy-gray hidden-phone'>
+            Petition Review
+          </h3>
+
+          <div
+            className='padding-left-15 form-wrapper background-moveon-light-gray padding-bottom-1'
+            style={{ paddingRight: '15px' }}
+          >
+            <div className='visible-phone'>
+              <p id='to-target' className='lh-16 margin-0 disclaimer'>
+                Petition statement to be delivered to{' '}
+                <span id='all-targets'>
+                  <strong>{getTargets(petition.target)}</strong>
+                </span>:
+              </p>
+
+              <h1 id='petition-title' className='moveon-bright-red big-title'>
+                {petition.title}
+              </h1>
+            </div>
+
+            {/* TODO: check user.authenticated and include a user update form (or just the launch button) */}
+            <RegisterForm
+              successCallback={onSubmit}
+              user={user}
+              includeZipAndPhone
+              useLaunchButton
+              useAlternateFields
+            />
+
+            <div className='bump-top-2 align-center percent-100'>
+              <a href='create_revise.html?skin=' className='size-small'>
+                <span className='triangle'>◀</span> Go back and fix something
+              </a>
+            </div>
+
+            <p className='bump-top-2 disclaimer align-center'>
+              By creating this petition, you agree to the Terms of Service (see
+              below) and to receive email messages from MoveOn.org Civic Action
+              and MoveOn.org Political Action. (You may unsubscribe at any
+              time.)
+            </p>
+          </div>
+        </div>
+
+        <div className='span8 pull-right petition-info-top'>
+          <div
+            className='percent-95 padding-left-15 form-wrapper responsive background-moveon-light-gray padding-bottom-1 padding-left-2 padding-right-3'
+            style={{ marginLeft: '-20px', position: 'relative' }}
+          >
+            <div className='hidden-phone'>
+              <p
+                id='to-target'
+                className='lh-16 margin-0 padding-top-1 disclaimer'
+              >
+                Petition statement to be delivered to{' '}
+                <span id='all-targets'>
+                  <strong>{getTargets(petition.target)}</strong>
+                </span>:
+              </p>
+
+              <h1 id='petition-title' className='moveon-bright-red big-title'>
+                {petition.title}
+              </h1>
+            </div>
+
+            <div
+              id='pet-statement'
+              className='lh-36 blockquote padding-bottom-1'
+            >
+              {petition.summary}
+            </div>
+          </div>
+
+          <div>
+            <div className='widget bump-top-1'>
+              <div className='padding-left-30'>
+                <div className='widget-top'>
+                  <h3 className='moveon-bright-red'>Petition Background</h3>
+                </div>
+                <p className='lh-30'>{petition.description}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+CreatePreview.propTypes = {
+  petition: PropTypes.object,
+  user: PropTypes.object,
+  onSubmit: PropTypes.func
+}

--- a/src/components/theme-legacy/register-form.js
+++ b/src/components/theme-legacy/register-form.js
@@ -1,105 +1,112 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const RegisterForm = ({ errorList, handleSubmit, setRef, isSubmitting }) => (
-  <div className='moveon-petitions'>
-    <div className='container'>
-      <div className='row'>
-        <div className='span6 offset3'>
-          <div className='well login clearfix'>
-            <h1 className='lanky-header size-xl'>Quick sign up</h1>
+const inputStyle = {
+  height: '17px',
+  marginBottom: '5px',
+  width: '95%'
+}
 
-            <ul className='errors'>{errorList && errorList()}</ul>
-
-            <form
-              method='POST'
-              onSubmit={handleSubmit}
-              className='form-horizontal'
+const RegisterForm = ({
+  errorList,
+  handleSubmit,
+  setRef,
+  isSubmitting,
+  includeZipAndPhone,
+  useLaunchButton,
+  useAlternateFields
+}) => (
+  <React.Fragment>
+    <ul className='errors'>{errorList && errorList()}</ul>
+    <form method='POST' onSubmit={handleSubmit} className='form-horizontal'>
+      <input
+        ref={setRef}
+        name='name'
+        className='percent-80 validation_error'
+        type='text'
+        id='inputName'
+        placeholder='Name'
+        style={useAlternateFields ? inputStyle : {}}
+      />
+      <input
+        ref={setRef}
+        name='email'
+        className='percent-80 validation_error'
+        type='text'
+        id='inputEmail'
+        placeholder='Email'
+        style={useAlternateFields ? inputStyle : {}}
+      />
+      {includeZipAndPhone && (
+        <input
+          ref={setRef}
+          autoComplete='off'
+          name='phone'
+          type='text'
+          placeholder='Phone (optional)'
+          style={useAlternateFields ? inputStyle : {}}
+        />
+      )}
+      {includeZipAndPhone && (
+        <input
+          ref={setRef}
+          required='required'
+          name='zip'
+          type='text'
+          placeholder='ZIP Code'
+          style={useAlternateFields ? inputStyle : {}}
+        />
+      )}
+      <input
+        name='password'
+        ref={setRef}
+        className='percent-80 validation_error'
+        type='password'
+        id='inputPassword'
+        placeholder='Password'
+        style={useAlternateFields ? inputStyle : {}}
+      />
+      <input
+        name='passwordConfirm'
+        ref={setRef}
+        className='percent-80 validation_error'
+        type='password'
+        id='inputConfirm'
+        placeholder='Confirm Password'
+        style={useAlternateFields ? inputStyle : {}}
+      />
+      <div>
+        <div className='bump-bottom-2'>
+          {useLaunchButton ? (
+            <button
+              type='submit'
+              className='xl percent-100 bump-top-3 background-moveon-bright-red'
+              id='sign-here-button'
             >
-              <input
-                ref={setRef}
-                name='name'
-                className='percent-80 validation_error'
-                type='text'
-                id='inputName'
-                placeholder='Name'
-              />
-              <input
-                ref={setRef}
-                name='email'
-                className='percent-80 validation_error'
-                type='text'
-                id='inputEmail'
-                placeholder='Email'
-              />
-              <input
-                name='password'
-                ref={setRef}
-                className='percent-80 validation_error'
-                type='password'
-                id='inputPassword'
-                placeholder='Password'
-              />
-              <input
-                name='passwordConfirm'
-                ref={setRef}
-                className='percent-80 validation_error'
-                type='password'
-                id='inputConfirm'
-                placeholder='Confirm Password'
-              />
-              <div>
-                <div className='bump-bottom-2'>
-                  <input
-                    value={isSubmitting ? 'Please wait...' : 'Register'}
-                    disabled={isSubmitting}
-                    className='button bump-top-2'
-                    type='submit'
-                  />
-                </div>
-                <ul className='unstyled inline'>
-                  <li className='disclaimer'>
-                    By creating an account you agree to receive email messages
-                    from MoveOn.org Civic Action and MoveOn.org Political Action.
-                    You may unsubscribe at any time.
-                  </li>
-                </ul>
-              </div>
-            </form>
-          </div>
-
-          <div className='disclaimer' id='privacy'>
-            <p>
-              <strong>Privacy Policy (the basics)</strong>:<br />
-              <br />{' '}
-              <strong>
-                MoveOn will never sell your personal information to anyone ever.
-              </strong>{' '}
-              For petitions, letters to the editor, and surveys you’ve signed or
-              completed, we treat your name, city, state, and comments as public
-              information, which means anyone can access and view it. We will not
-              make your street address publicly available, but we may transmit it
-              to your state legislators, governor, members of Congress, or the
-              President as part of a petition. MoveOn will send you updates on
-              this and other important campaigns by email. If at any time you
-              would like to unsubscribe from our email list, you may do so. For
-              our complete privacy policy,{' '}
-              <a href='http://petitions.moveon.org/privacy.html' target='_blank' rel='noopener noreferrer'>
-                click here
-              </a>.
-            </p>
-          </div>
+              Launch petition
+            </button>
+          ) : (
+            <input
+              value={isSubmitting ? 'Please wait...' : 'Register'}
+              disabled={isSubmitting}
+              className='button bump-top-2'
+              type='submit'
+            />
+          )}
         </div>
       </div>
-    </div>
-  </div>
+    </form>
+  </React.Fragment>
 )
 
 RegisterForm.propTypes = {
   errorList: PropTypes.func,
   handleSubmit: PropTypes.func,
   setRef: PropTypes.func,
-  isSubmitting: PropTypes.bool
+  isSubmitting: PropTypes.bool,
+  includeZipAndPhone: PropTypes.bool,
+  useLaunchButton: PropTypes.bool,
+  useAlternateFields: PropTypes.bool
 }
 
 export default RegisterForm

--- a/src/components/theme-legacy/register.js
+++ b/src/components/theme-legacy/register.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import RegisterForm from '../../containers/register-form'
+
+export const Register = () => (
+  <div className='moveon-petitions'>
+    <div className='container'>
+      <div className='row'>
+        <div className='span6 offset3'>
+          <div className='well login clearfix'>
+            <h1 className='lanky-header size-xl'>Quick sign up</h1>
+            <RegisterForm />
+            <ul className='unstyled inline'>
+              <li className='disclaimer'>
+                By creating an account you agree to receive email messages from
+                MoveOn.org Civic Action and MoveOn.org Political Action. You may
+                unsubscribe at any time.
+              </li>
+            </ul>
+            <div className='disclaimer' id='privacy'>
+              <p>
+                <strong>Privacy Policy (the basics)</strong>:<br />
+                <br />{' '}
+                <strong>
+                  MoveOn will never sell your personal information to anyone
+                  ever.
+                </strong>{' '}
+                For petitions, letters to the editor, and surveys you’ve signed
+                or completed, we treat your name, city, state, and comments as
+                public information, which means anyone can access and view it.
+                We will not make your street address publicly available, but we
+                may transmit it to your state legislators, governor, members of
+                Congress, or the President as part of a petition. MoveOn will
+                send you updates on this and other important campaigns by email.
+                If at any time you would like to unsubscribe from our email
+                list, you may do so. For our complete privacy policy,{' '}
+                <a
+                  href='http://petitions.moveon.org/privacy.html'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  click here
+                </a>.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+Register.propTypes = {}
+
+export default Register

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ export const Config = {
   ONLY_PROD_ROUTES: process.env.ONLY_PROD_ROUTES || '',
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',
-  USE_HASH_BROWSING: process.env.USE_HASH_BROWSING,
+  USE_HASH_BROWSING: process.env.USE_HASH_BROWSING || process.env.NODE_ENV === 'test',
   STATIC_ROOT: process.env.STATIC_ROOT,
   WORDPRESS_API_URI: process.env.WORDPRESS_API_URI
 }

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { appLocation } from '../routes'
 import { previewSubmit } from '../actions/createPetitionActions'
 
 import CreatePetitionForm from 'LegacyTheme/create-petition-form'
@@ -43,6 +44,7 @@ export class CreatePetition extends React.Component {
           description: this.state.description
         })
       )
+      appLocation.push('/create_preview.html')
     }
   }
 

--- a/src/containers/create-preview.js
+++ b/src/containers/create-preview.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { appLocation } from '../routes'
+
+// import { submitPetition } from '../actions/createPetitionActions'
+
+import { CreatePreview as CreatePreviewComponent } from 'LegacyTheme/create-preview'
+
+class CreatePreview extends React.Component {
+  constructor(props) {
+    super(props)
+    this.submitPetition = this.submitPetition.bind(this)
+  }
+  componentDidMount() {
+    if (!this.props.hasPetition) appLocation.push('/create_start.html')
+  }
+
+  // eslint-disable-next-line
+  submitPetition() {
+    return null
+    // this.props.dispatch(submitPetition())
+  }
+
+  render() {
+    if (!this.props.hasPetition) return null // We will also redirect in componentDidMount
+    return (
+      <CreatePreviewComponent
+        petition={this.props.petition}
+        user={this.props.user}
+        onSubmit={this.submitPetition}
+      />
+    )
+  }
+}
+
+CreatePreview.propTypes = {
+  hasPetition: PropTypes.bool,
+  petition: PropTypes.object,
+  user: PropTypes.object
+  // dispatch: PropTypes.func
+}
+
+function mapStateToProps({ petitionCreateStore, userStore }) {
+  return {
+    hasPetition: !!petitionCreateStore.title,
+    petition: petitionCreateStore,
+    user: userStore
+  }
+}
+
+export default connect(mapStateToProps)(CreatePreview)

--- a/src/containers/register-form.js
+++ b/src/containers/register-form.js
@@ -98,6 +98,8 @@ class Register extends React.Component {
         setRef={input => input && (this[input.name] = input)}
         isSubmitting={this.props.isSubmitting}
         includeZipAndPhone={this.props.includeZipAndPhone}
+        useLaunchButton={this.props.useLaunchButton}
+        useAlternateFields={this.props.useAlternateFields}
       />
     )
   }
@@ -112,6 +114,8 @@ Register.propTypes = {
   dispatch: PropTypes.func,
   isSubmitting: PropTypes.bool,
   includeZipAndPhone: PropTypes.bool,
+  useLaunchButton: PropTypes.bool,
+  useAlternateFields: PropTypes.bool,
   successCallback: PropTypes.func
 }
 

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -23,6 +23,11 @@ export const LoadableCreate = Loadable({
   loading: Loading
 })
 
+export const LoadablePreview = Loadable({
+  loader: () => import('../containers/create-preview'),
+  loading: Loading
+})
+
 export const LoadableRegister = Loadable({
   loader: () => import('LegacyTheme/register'),
   loading: Loading

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -24,7 +24,7 @@ export const LoadableCreate = Loadable({
 })
 
 export const LoadableRegister = Loadable({
-  loader: () => import('../containers/register'),
+  loader: () => import('LegacyTheme/register'),
   loading: Loading
 })
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ import {
   LoadableDashboard,
   LoadableNoPetition,
   LoadableCreate,
+  LoadablePreview,
   LoadableRegister,
   LoadableLogin,
   LoadableStatic,
@@ -104,6 +105,7 @@ export const routes = store => {
       <Route path=':organization/thanks.html' component={ThanksShim} onEnter={orgLoader} prodReady minimalNav />
       <Route path='find' component={LoadableSearch} />
       <Route path='create_start.html' component={LoadableCreate} minimalNav />
+      <Route path='create_preview.html' component={LoadablePreview} minimalNav />
       <Route path='petition_report.html' component={LoadablePetitionReport} />
       <Route path=':organization/create_start.html' component={LoadableCreate} onEnter={orgLoader} minimalNav />
       <Route path='login/' component={LoadableLogin} />


### PR DESCRIPTION
Adds the create_preview.html route, which previews the petition in the redux store (that you presumably just created at create_start.html).

I refactored the register page so that `LegacyTheme/register` is just the wrapper with the things on the register page for RegisterForm, which contains all the inputs and logic.

This is so we can also include RegisterForm on PetitionPreview, so people can register as they create a petition.

Still to come is the logic for submitting the petition to the API, plus the form that is shown instead of RegisterForm if you are logged in.

I will also need to rebase https://github.com/MoveOnOrg/mop-frontend/pull/493 on this one (just for the /register refactor, there's still no giraffe create-petition)

Closes #339 