### PR TITLE
Ability to revise petition during creation

### DIFF
--- a/src/components/theme-legacy/create-preview.js
+++ b/src/components/theme-legacy/create-preview.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Link } from 'react-router'
 
 import RegisterForm from '../../containers/register-form'
 
@@ -41,9 +42,9 @@ export const CreatePreview = ({ petition, user, onSubmit }) => (
             />
 
             <div className='bump-top-2 align-center percent-100'>
-              <a href='create_revise.html?skin=' className='size-small'>
+              <Link to='/create_revise.html' className='size-small'>
                 <span className='triangle'>◀</span> Go back and fix something
-              </a>
+              </Link>
             </div>
 
             <p className='bump-top-2 disclaimer align-center'>

--- a/src/components/theme-legacy/form/target-select/state.js
+++ b/src/components/theme-legacy/form/target-select/state.js
@@ -8,6 +8,11 @@ import StateSelect from '../state-select'
 const isDefault = target =>
   ['governor', 'statehouse', 'statesenate'].indexOf(target.target_type) !== -1
 
+const contains = (item, list) =>
+  list.filter(
+    t => t.target_type === item.target_type && t.target_id === item.target_id
+  ).length > 0
+
 const StateTargetSelect = ({
   selected,
   remove,
@@ -30,11 +35,8 @@ const StateTargetSelect = ({
     </div>
     <div id='state_group_checkboxes'>
       {autocompleteItems.filter(isDefault).map(defaultItem => {
-        const isChecked = selected.filter(
-          t =>
-            t.target_type === defaultItem.target_type &&
-            t.target_id === defaultItem.target_id
-        ).length
+        // isChecked means if the autocomplete item is in the selected items
+        const isChecked = contains(defaultItem, selected)
         return (
           <div key={defaultItem.label} className='checkbox wrapper'>
             <label>
@@ -50,27 +52,30 @@ const StateTargetSelect = ({
           </div>
         )
       })}
-      {selected.filter(t => !isDefault(t)).map(selectedItem => (
-        <div key={selectedItem.label} className='checkbox wrapper'>
-          <label>
-            <input
-              type='checkbox'
-              onChange={() => remove(selectedItem)}
-              checked
-            />{' '}
-            {selectedItem.label}
-          </label>
-        </div>
-      ))}
+      {/* Also show if not a default, or it's from another geoState (not preloaded into autocompleteItems) */}
+      {selected
+        .filter(t => !isDefault(t) || !contains(t, autocompleteItems))
+        .map(selectedItem => (
+          <div key={selectedItem.label} className='checkbox wrapper'>
+            <label>
+              <input
+                type='checkbox'
+                onChange={() => remove(selectedItem)}
+                checked
+              />{' '}
+              {selectedItem.label}
+            </label>
+          </div>
+        ))}
     </div>
     <div className='autocomplete_wrapper text wrapper small'>
-      {geoState &&
+      {geoState && (
         <LegislatorAutocomplete
           group='national'
           onChange={onSelect}
           items={autocompleteItems.filter(t => !isDefault(t))}
         />
-      }
+      )}
     </div>
   </div>
 )

--- a/src/containers/create-preview.js
+++ b/src/containers/create-preview.js
@@ -43,7 +43,7 @@ CreatePreview.propTypes = {
 
 function mapStateToProps({ petitionCreateStore, userStore }) {
   return {
-    hasPetition: !!petitionCreateStore.title,
+    hasPetition: !!(petitionCreateStore && petitionCreateStore.title),
     petition: petitionCreateStore,
     user: userStore
   }

--- a/src/containers/create-revise.js
+++ b/src/containers/create-revise.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import { appLocation } from '../routes'
+import CreatePetition from './create-petition'
+
+class CreateRevise extends React.Component {
+  componentDidMount() {
+    if (!this.props.hasPetition) appLocation.push('/create_start.html')
+  }
+
+  render() {
+    if (!this.props.hasPetition) return null // We will also redirect in componentDidMount
+    return <CreatePetition initialPetition={this.props.petition} />
+  }
+}
+
+function mapStateToProps({ petitionCreateStore }) {
+  return {
+    hasPetition: !!(petitionCreateStore && petitionCreateStore.title),
+    petition: petitionCreateStore
+  }
+}
+
+CreateRevise.propTypes = {
+  hasPetition: PropTypes.bool,
+  petition: PropTypes.object
+}
+
+export default connect(mapStateToProps)(CreateRevise)

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -28,6 +28,11 @@ export const LoadablePreview = Loadable({
   loading: Loading
 })
 
+export const LoadableRevise = Loadable({
+  loader: () => import('../containers/create-revise'),
+  loading: Loading
+})
+
 export const LoadableRegister = Loadable({
   loader: () => import('LegacyTheme/register'),
   loading: Loading

--- a/src/routes.js
+++ b/src/routes.js
@@ -22,6 +22,7 @@ import {
   LoadableNoPetition,
   LoadableCreate,
   LoadablePreview,
+  LoadableRevise,
   LoadableRegister,
   LoadableLogin,
   LoadableStatic,
@@ -106,6 +107,7 @@ export const routes = store => {
       <Route path='find' component={LoadableSearch} />
       <Route path='create_start.html' component={LoadableCreate} minimalNav />
       <Route path='create_preview.html' component={LoadablePreview} minimalNav />
+      <Route path='create_revise.html' component={LoadableRevise} minimalNav />
       <Route path='petition_report.html' component={LoadablePetitionReport} />
       <Route path=':organization/create_start.html' component={LoadableCreate} onEnter={orgLoader} minimalNav />
       <Route path='login/' component={LoadableLogin} />

--- a/test/components/create-petition.js
+++ b/test/components/create-petition.js
@@ -83,7 +83,7 @@ describe('<CreatePetition />', () => {
     expect(component.state('errors').length).to.equal(3)
   })
 
-  it('submitting petition for preview fires the action', () => {
+  it('submitting petition for preview fires the action and redirects', () => {
     const dispatch = sinon.spy()
     const component = shallow(<CreatePetitionUnwrapped dispatch={dispatch} />)
     const petition = {
@@ -95,5 +95,6 @@ describe('<CreatePetition />', () => {
     component.setState(petition)
     component.instance().onPreview({ preventDefault: () => {} })
     expect(dispatch.calledOnce).to.be.true
+    expect(document.location.toString()).to.contain('create_preview.html')
   })
 })

--- a/test/components/create-petition.js
+++ b/test/components/create-petition.js
@@ -95,6 +95,8 @@ describe('<CreatePetition />', () => {
     component.setState(petition)
     component.instance().onPreview({ preventDefault: () => {} })
     expect(dispatch.calledOnce).to.be.true
+    expect(dispatch.firstCall.args[0].type).to.equal('CREATE_PETITION_PREVIEW_SUBMIT')
+    expect(dispatch.firstCall.args[0]).to.contain(petition)
     expect(document.location.toString()).to.contain('create_preview.html')
   })
 })

--- a/test/components/create-preview.js
+++ b/test/components/create-preview.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { expect } from 'chai'
+
+import { Provider } from 'react-redux'
+import { createMockStore } from 'redux-test-utils'
+
+import { mount } from 'enzyme'
+
+import CreatePreview from '../../src/containers/create-preview'
+import RegisterForm from '../../src/containers/register-form'
+
+describe('<CreatePreview />', () => {
+  const petition = {
+    title: 'testtitle',
+    target: [{ name: 'testtarget' }],
+    summary: 'testsummary',
+    description: 'testdescription'
+  }
+  const store = createMockStore({ petitionCreateStore: petition })
+  const preview = mount(
+    <Provider store={store}>
+      <CreatePreview />
+    </Provider>
+  )
+
+  it('displays title', () => {
+    expect(preview.text()).to.contain('testtitle')
+  })
+
+  it('displays target', () => {
+    expect(preview.text()).to.contain('to be delivered to testtarget')
+  })
+
+  it('displays summary', () => {
+    expect(preview.text()).to.contain('testsummary')
+  })
+
+  it('displays description', () => {
+    expect(preview.text()).to.contain('testdescription')
+  })
+
+  it('displays register form', () => {
+    const form = preview.find(RegisterForm)
+    expect(form.length).to.equal(1)
+    expect(form.props()).to.contain({
+      includeZipAndPhone: true,
+      useAlternateFields: true,
+      useLaunchButton: true
+    })
+    expect(typeof form.prop('successCallback')).to.equal('function')
+  })
+
+  it('redirects when there is no petition', () => {
+    const emptyStore = createMockStore({ petitionCreateStore: {} })
+    mount(
+      <Provider store={emptyStore}>
+        <CreatePreview />
+      </Provider>
+    )
+    expect(document.location.toString()).to.contain('create_start.html')
+  })
+})

--- a/test/components/create-revise.js
+++ b/test/components/create-revise.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { expect } from 'chai'
+
+import { Provider } from 'react-redux'
+import { createMockStore } from 'redux-test-utils'
+
+import { mount } from 'enzyme'
+
+import CreateRevise from '../../src/containers/create-revise'
+import { CreatePetition } from '../../src/containers/create-petition'
+
+
+describe('<CreateRevise />', () => {
+  const petition = {
+    title: 'testtitle',
+    target: [
+      {
+        label: 'Governor of Florida',
+        target_type: 'governor',
+        target_id: 'FL'
+      }],
+    summary: 'testsummary',
+    description: 'testdescription'
+  }
+
+  const store = createMockStore({
+    petitionCreateStore: petition
+  })
+
+  const revise = mount(
+    <Provider store={store}>
+      <CreateRevise />
+    </Provider>
+  )
+
+  it('loads the create page', () => {
+    expect(revise.text()).to.contain('Start your petition')
+  })
+
+  it('displays title', () => {
+    expect(revise.find('input[name="title"]').prop('value')).to.equal('testtitle')
+  })
+
+  it('displays target', () => {
+    expect(revise.text()).to.contain('Governor of Florida')
+  })
+
+  it('displays summary', () => {
+    expect(revise.find('textarea[name="summary"]').text()).to.equal('testsummary')
+  })
+
+  it('displays description', () => {
+    expect(revise.text()).to.contain('testdescription')
+  })
+
+  it('passes the stored petition to <CreatePetition />', () => {
+    const createPetition = revise.find(CreatePetition)
+    expect(createPetition.length).to.equal(1)
+    expect(createPetition.prop('initialPetition')).to.equal(petition)
+  })
+
+  it('redirects when there is no petition', () => {
+    mount(
+      <Provider store={createMockStore({ petitionCreateStore: {} })}>
+        <CreateRevise />
+      </Provider>
+    )
+    expect(document.location.toString()).to.contain('/create_start.html')
+  })
+})


### PR DESCRIPTION
Adds the create-revise route and container, which basically just wraps CreatePetition and passes an initialPetition from the redux state.

Plus a few fixes for targets to show up correctly when they are being revised.

Plus some tests for previewing and revision.