### PR TITLE
Add custom target input fields to target list before verification

### DIFF
--- a/src/components/theme-legacy/create-petition-form.js
+++ b/src/components/theme-legacy/create-petition-form.js
@@ -32,7 +32,9 @@ const CreatePetitionForm = ({
   description,
   targets,
   onTargetAdd,
-  onTargetRemove
+  onTargetRemove,
+  customInputs,
+  onChangeCustomInputs
 }) => {
   const instructions = instructionsByField[selected]
 
@@ -90,6 +92,8 @@ const CreatePetitionForm = ({
               targets={targets}
               onTargetAdd={onTargetAdd}
               onTargetRemove={onTargetRemove}
+              customInputs={customInputs}
+              onChangeCustomInputs={onChangeCustomInputs}
             />
             <fieldset id='statement'>
               <span className='circle-number'>3</span>
@@ -146,7 +150,9 @@ CreatePetitionForm.propTypes = {
   description: PropTypes.string,
   targets: PropTypes.array,
   onTargetAdd: PropTypes.func,
-  onTargetRemove: PropTypes.func
+  onTargetRemove: PropTypes.func,
+  customInputs: PropTypes.object,
+  onChangeCustomInputs: PropTypes.func
 }
 
 export default CreatePetitionForm

--- a/src/containers/create-petition-target.js
+++ b/src/containers/create-petition-target.js
@@ -16,8 +16,7 @@ export class CreatePetitionTarget extends React.Component {
       nationalOpen: false,
       geoState: null,
       stateOpen: false,
-      customOpen: false,
-      customInputs: { name: '', email: '', title: '' }
+      customOpen: false
     }
 
     this.toggleOpen = this.toggleOpen.bind(this)
@@ -103,7 +102,7 @@ export class CreatePetitionTarget extends React.Component {
   }
 
   renderCustom() {
-    const { customOpen, customInputs } = this.state
+    const { customOpen } = this.state
     if (!customOpen) return null
     return (
       <CustomTargetSelect
@@ -111,14 +110,9 @@ export class CreatePetitionTarget extends React.Component {
         remove={this.props.onTargetRemove}
         onSelect={target => {
           this.props.onTargetAdd(target, { isCustom: true })
-          this.setState({ customInputs: { name: '', email: '', title: '' } })
         }}
-        customInputs={customInputs}
-        onChangeInputs={({ target: { name, value } }) => {
-          this.setState(state => ({
-            customInputs: { ...state.customInputs, [name]: value }
-          }))
-        }}
+        customInputs={this.props.customInputs}
+        onChangeInputs={this.props.onChangeCustomInputs}
       />
     )
   }
@@ -149,7 +143,9 @@ CreatePetitionTarget.propTypes = {
   onTargetRemove: PropTypes.func,
   dispatch: PropTypes.func,
   // eslint-disable-next-line
-  targets: PropTypes.array
+  targets: PropTypes.array,
+  customInputs: PropTypes.object,
+  onChangeCustomInputs: PropTypes.func
 }
 
 export default connect()(CreatePetitionTarget)

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -48,10 +48,7 @@ export class CreatePetition extends React.Component {
       },
       {
         isCustom: true,
-        callback: () => {
-          this.setState({ customInputs: { name: '', email: '', title: '' } })
-          this.validateAndContinue()
-        }
+        callback: this.validateAndContinue
       }
     )
   }
@@ -62,6 +59,10 @@ export class CreatePetition extends React.Component {
   ) {
     if (!isCustom && !target.label) return // target is invalid
     if (!isCustom && this.state.target.find(old => old.label === target.label)) return // already exists
+
+    if (isCustom) {
+      this.setState({ customInputs: { name: '', email: '', title: '' } })
+    }
 
     this.setState(
       state => ({ target: [...state.target, target] }),
@@ -142,7 +143,9 @@ export class CreatePetition extends React.Component {
           selected={this.state.selected}
           instructionStyle={instructionStyle}
           errors={this.state.errors}
-          onChange={({ target: { name, value } }) => this.setState({ [name]: value })}
+          onChange={({ target: { name, value } }) =>
+            this.setState({ [name]: value })
+          }
           onPreview={this.onPreview}
           title={this.state.title}
           summary={this.state.summary}

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -24,35 +24,49 @@ export class CreatePetition extends React.Component {
       title: initialPetition.title || '',
       summary: initialPetition.summary || '',
       target: initialPetition.target || [],
-      description: initialPetition.description || ''
+      description: initialPetition.description || '',
+      customInputs: { name: '', email: '', title: '' }
     }
     this.setSelected = this.setSelected.bind(this)
     this.setRef = this.setRef.bind(this)
     this.onPreview = this.onPreview.bind(this)
     this.onTargetAdd = this.onTargetAdd.bind(this)
     this.onTargetRemove = this.onTargetRemove.bind(this)
+    this.validateAndContinue = this.validateAndContinue.bind(this)
   }
 
   onPreview(event) {
     event.preventDefault()
-    if (this.formIsValid()) {
-      this.props.dispatch(
-        previewSubmit({
-          title: this.state.title,
-          summary: this.state.summary,
-          target: this.state.target,
-          description: this.state.description
-        })
-      )
-      appLocation.push('/create_preview.html')
-    }
+    // No custom target in the editable fields
+    if (!this.state.customInputs.name) return this.validateAndContinue()
+
+    // If there is a custom target, we have to add it first
+    return this.onTargetAdd(
+      {
+        target_type: 'custom',
+        ...this.state.customInputs
+      },
+      {
+        isCustom: true,
+        callback: () => {
+          this.setState({ customInputs: { name: '', email: '', title: '' } })
+          this.validateAndContinue()
+        }
+      }
+    )
   }
 
-  onTargetAdd(target, { isCustom } = { isCustom: false }) {
+  onTargetAdd(
+    target,
+    { isCustom, callback } = { isCustom: false, callback: () => {} }
+  ) {
     if (!isCustom && !target.label) return // target is invalid
     if (!isCustom && this.state.target.find(old => old.label === target.label)) return // already exists
 
-    this.setState(state => ({ target: [...state.target, target] }))
+    this.setState(
+      state => ({ target: [...state.target, target] }),
+      () => callback && callback()
+    )
   }
 
   onTargetRemove(target) {
@@ -70,6 +84,20 @@ export class CreatePetition extends React.Component {
   setRef(name) {
     // eslint-disable-next-line no-return-assign
     return input => input && (this[name] = input)
+  }
+
+  validateAndContinue() {
+    if (this.formIsValid()) {
+      this.props.dispatch(
+        previewSubmit({
+          title: this.state.title,
+          summary: this.state.summary,
+          target: this.state.target,
+          description: this.state.description
+        })
+      )
+      appLocation.push('/create_preview.html')
+    }
   }
 
   formIsValid() {
@@ -122,6 +150,12 @@ export class CreatePetition extends React.Component {
           targets={this.state.target}
           onTargetAdd={this.onTargetAdd}
           onTargetRemove={this.onTargetRemove}
+          customInputs={this.state.customInputs}
+          onChangeCustomInputs={({ target: { name, value } }) => {
+            this.setState(state => ({
+              customInputs: { ...state.customInputs, [name]: value }
+            }))
+          }}
         />
       </div>
     )


### PR DESCRIPTION
As discovered in #550, the input fields for a custom target should be added as a custom target.

I've opted to add these input fields into the `state.target` array on submit, if they exist, before the verification and the submission to the redux store occurs.

This means that the target moves from the fields to a checkbox if the verification fails and on revision. Hope this is OK.

To do this, I've moved the custom input fields state up into the CreatePetition component.

fixes #550.