### PR TITLE
Petition create tracking

### DIFF
--- a/docs/REFERENCE--environment_variables.md
+++ b/docs/REFERENCE--environment_variables.md
@@ -6,6 +6,7 @@ APP_ENTRY                         | For WebPack build, file name for app. _Defau
 API_SIGN_PETITION                 | Full url endpoint to send submitted signatures to.  Without this, it will default to `${API_URI}/signatures`
 WORDPRESS_API_URI                 | Base URI for the wordpress API, to fetch content for static pages. _Required in prod_. _Dev default_:"/local/api"
 BASE_APP_PATH                     | If the app is being served from a path other than the domain root, set this to that path. _Default_: "/".
+GTAG_PETITION_CREATE              | The `send_to` param for tracking petition create conversions for Google
 ONLY_PROD_ROUTES                  | Only render production-ready routes (marked `prodReady`) and redirect all other paths to petitions.moveon.org
 PROD                              | Boolean value indicating whether site should act as a production environment. _Options_: 0, 1. _Default_: "".
 PUBLIC_ROOT                       | For WebPack dev server, the directory relative to server root where files are found. _Default_: "/".

--- a/src/actions/createPetitionActions.js
+++ b/src/actions/createPetitionActions.js
@@ -39,6 +39,11 @@ export function submit() {
     dispatch({
       type: actionTypes.CREATE_PETITION_REQUEST
     })
+    if (window.gtag && Config.GTAG_PETITION_CREATE) {
+      // https://developers.google.com/adwords-remarketing-tag/
+      window.gtag('event', 'conversion', { send_to: Config.GTAG_PETITION_CREATE })
+    }
+
     const { petitionCreateStore: p } = getState()
     const petition = {
       title: p.title,

--- a/src/actions/createPetitionActions.js
+++ b/src/actions/createPetitionActions.js
@@ -13,13 +13,24 @@ export const actionTypes = {
   FETCH_TARGETS_FAILURE: 'FETCH_TARGETS_FAILURE'
 }
 
-export function previewSubmit({ title, summary, description, target }) {
+export function previewSubmit({
+  title,
+  summary,
+  description,
+  target,
+  source,
+  clonedFromId,
+  solicitId
+}) {
   return {
     type: actionTypes.CREATE_PETITION_PREVIEW_SUBMIT,
     title,
     summary,
     description,
-    target
+    target,
+    source,
+    clonedFromId,
+    solicitId
   }
 }
 
@@ -29,40 +40,40 @@ export function submit() {
       type: actionTypes.CREATE_PETITION_REQUEST
     })
     const { petitionCreateStore: p } = getState()
-    return (
-      fetch(`${Config.API_URI}/user/petitions.json`, {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/hal+json',
-          Accept: 'application/hal+json'
-        },
-        body: JSON.stringify({
-          petition: {
-            title: p.title,
-            summary: p.summary,
-            description: p.description,
-            targets: p.target
-          }
+    const petition = {
+      title: p.title,
+      summary: p.summary,
+      description: p.description,
+      targets: p.target
+    }
+    if (p.source) petition.source = p.source
+    if (p.cloned_from_id) petition.cloned_from_id = p.cloned_from_id
+    if (p.solicit_id) petition.solicit_id = p.solicit_id
+    return fetch(`${Config.API_URI}/user/petitions.json`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/hal+json',
+        Accept: 'application/hal+json'
+      },
+      body: JSON.stringify({ petition })
+    })
+      .catch(rejectNetworkErrorsAs500)
+      .then(parseAPIResponse)
+      .then(res => {
+        dispatch({
+          type: actionTypes.CREATE_PETITION_SUCCESS,
+          petition: res
+        })
+        appLocation.push('/create_finished.html')
+      })
+      .catch(err => {
+        // For now, treat every error as a 500 to just show the error page
+        dispatch({
+          type: actionTypes.CREATE_PETITION_FAILURE,
+          error: { ...err, response_code: 500 }
         })
       })
-        .catch(rejectNetworkErrorsAs500)
-        .then(parseAPIResponse)
-        .then(res => {
-          dispatch({
-            type: actionTypes.CREATE_PETITION_SUCCESS,
-            petition: res
-          })
-          appLocation.push('/create_finished.html')
-        })
-        .catch(err => {
-          // For now, treat every error as a 500 to just show the error page
-          dispatch({
-            type: actionTypes.CREATE_PETITION_FAILURE,
-            error: { ...err, response_code: 500 }
-          })
-        })
-    )
   }
 }
 

--- a/src/components/theme-legacy/create-petition-form.js
+++ b/src/components/theme-legacy/create-petition-form.js
@@ -43,12 +43,6 @@ const CreatePetitionForm = ({
       <div className='row'>
         <div className='background-moveon-light-gray span6 start-form'>
           <form id='petition_form' onSubmit={onPreview}>
-            {/* TODO: Do we need to move these to the state to submit? */}
-            <input value='' name='targets' id='targets_json' type='hidden' />
-            <input value='' name='skin' type='hidden' />
-            <input value='' name='source' type='hidden' />
-            <input value='' name='cloned_from_id' type='hidden' />
-            <input value='' name='solicit_id' type='hidden' />
             <ul className='errors'>
               {errors.map(err => <li key={err}>{err}</li>)}
             </ul>

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ export const Config = {
   API_SIGN_PETITION: process.env.API_SIGN_PETITION || '',
   BASE_APP_PATH: process.env.BASE_APP_PATH,
   BASE_URL: process.env.BASE_URL || '',
+  GTAG_PETITION_CREATE: process.env.GTAG_PETITION_CREATE,
   ONLY_PROD_ROUTES: process.env.ONLY_PROD_ROUTES || '',
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 
 import { appLocation } from '../routes'
 import { previewSubmit } from '../actions/createPetitionActions'
@@ -17,15 +18,21 @@ const ERRORS = {
 export class CreatePetition extends React.Component {
   constructor(props) {
     super(props)
-    const { initialPetition } = this.props
+    const { initialPetition, location } = this.props
+    const query = (location && location.query) || {}
     this.state = {
       selected: 'title',
       errors: [],
+      customInputs: { name: '', email: '', title: '' },
+
       title: initialPetition.title || '',
       summary: initialPetition.summary || '',
       target: initialPetition.target || [],
       description: initialPetition.description || '',
-      customInputs: { name: '', email: '', title: '' }
+
+      source: initialPetition.source || query.source,
+      clonedFromId: initialPetition.cloned_from_id || query.cloned_from_id,
+      solicitId: initialPetition.solicit_id || query.solicit_id
     }
     this.setSelected = this.setSelected.bind(this)
     this.setRef = this.setRef.bind(this)
@@ -94,7 +101,10 @@ export class CreatePetition extends React.Component {
           title: this.state.title,
           summary: this.state.summary,
           target: this.state.target,
-          description: this.state.description
+          description: this.state.description,
+          source: this.state.source,
+          clonedFromId: this.state.clonedFromId,
+          solicitId: this.state.solicitId
         })
       )
       appLocation.push('/create_preview.html')
@@ -171,7 +181,8 @@ CreatePetition.defaultProps = {
 
 CreatePetition.propTypes = {
   dispatch: PropTypes.func,
-  initialPetition: PropTypes.object
+  initialPetition: PropTypes.object,
+  location: PropTypes.object
 }
 
-export default connect()(CreatePetition)
+export default withRouter(connect()(CreatePetition))

--- a/src/reducers/petition-create.js
+++ b/src/reducers/petition-create.js
@@ -9,7 +9,10 @@ const reducer = (state = {}, action) => {
         title: action.title,
         summary: action.summary,
         description: action.description,
-        target: action.target
+        target: action.target,
+        source: action.source,
+        cloned_from_id: action.clonedFromId,
+        solicit_id: action.solicitId
       }
     case actionTypes.CREATE_PETITION_REQUEST:
       return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ var envVars = {
   'API_SIGN_PETITION': process.env.API_SIGN_PETITION || '',
   'BASE_APP_PATH': process.env.BASE_APP_PATH || '/',
   'BASE_URL': process.env.BASE_URL || (process.env.PROD ? 'https://petitions.moveon.org' : ''),
+  'GTAG_PETITION_CREATE': process.env.GTAG_PETITION_CREATE,
   'ONLY_PROD_ROUTES': process.env.ONLY_PROD_ROUTES || '',
   'SESSION_COOKIE_NAME': process.env.SESSION_COOKIE_NAME || 'SO_SESSION',
   'STATIC_ROOT': process.env.STATIC_ROOT || '/local/',


### PR DESCRIPTION
Uses env var GTAG_PETITION_CREATE  for the `send_to` param for tracking petition create conversions to Google.

Allows source, cloned_from_id, and solicit_id to be submitted along with the petition create request if set in the query parameters of create_start.html. Shouldn't include them in the request if not set.

closes #556 
closes #557