### PR TITLE
Have travis cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
 - '6.1'
+cache:
+  directories:
+    - node_modules
 script:
   - npm run lint
   - THEME=legacy npm run test


### PR DESCRIPTION
For faster builds.

I don't think (?) it will mess anything up, because it will still run `npm install`, just with the `node_modules` folder already the same as last build.

https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies