### PR TITLE
Support authenticated users when creating a petition

### DIFF
--- a/src/actions/createPetitionActions.js
+++ b/src/actions/createPetitionActions.js
@@ -34,7 +34,7 @@ export function previewSubmit({
   }
 }
 
-export function submit() {
+export function submit(newZip) {
   return (dispatch, getState) => {
     dispatch({
       type: actionTypes.CREATE_PETITION_REQUEST
@@ -54,6 +54,14 @@ export function submit() {
     if (p.source) petition.source = p.source
     if (p.cloned_from_id) petition.cloned_from_id = p.cloned_from_id
     if (p.solicit_id) petition.solicit_id = p.solicit_id
+
+    const body = { petition }
+
+    if (newZip) {
+      body.person = {
+        postal_addresses: [{ postal_code: newZip }]
+      }
+    }
     return fetch(`${Config.API_URI}/user/petitions.json`, {
       method: 'POST',
       credentials: 'same-origin',
@@ -61,7 +69,7 @@ export function submit() {
         'Content-Type': 'application/hal+json',
         Accept: 'application/hal+json'
       },
-      body: JSON.stringify({ petition })
+      body: JSON.stringify(body)
     })
       .catch(rejectNetworkErrorsAs500)
       .then(parseAPIResponse)

--- a/src/components/theme-giraffe/edit-user-form.js
+++ b/src/components/theme-giraffe/edit-user-form.js
@@ -8,12 +8,9 @@ const inputStyle = {
   width: '95%'
 }
 
-const hasZip = (user = {}) => Array.isArray(user.postal_addresses) &&
-  user.postal_addresses.filter(e => e.no_zip).length === 0
-
 const EditUserForm = ({ user, handleSubmit, zip, onChangeZip, isSubmitting }) => (
   <form onSubmit={handleSubmit}>
-    {!hasZip(user) && (
+    { user.no_zip && (
       <input
         value={zip}
         onChange={onChangeZip}

--- a/src/components/theme-giraffe/edit-user-form.js
+++ b/src/components/theme-giraffe/edit-user-form.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+const inputStyle = {
+  height: '17px',
+  marginBottom: '5px',
+  width: '95%'
+}
+
+const hasZip = (user = {}) => Array.isArray(user.postal_addresses) &&
+  user.postal_addresses.filter(e => e.no_zip).length === 0
+
+const EditUserForm = ({ user, handleSubmit, zip, onChangeZip, isSubmitting }) => (
+  <form onSubmit={handleSubmit}>
+    {!hasZip(user) && (
+      <input
+        value={zip}
+        onChange={onChangeZip}
+        name='zip'
+        type='text'
+        placeholder='Zip'
+        style={inputStyle}
+        required
+      />
+    )}
+    <button
+      type='submit'
+      className='xl percent-100 bump-top-3 background-moveon-bright-red'
+      id='sign-here-button'
+      disabled={isSubmitting}
+    >
+      {isSubmitting ? 'Please wait...' : 'Launch petition'}
+    </button>
+  </form>
+)
+
+EditUserForm.propTypes = {
+  handleSubmit: PropTypes.func,
+  user: PropTypes.object,
+  zip: PropTypes.string,
+  onChangeZip: PropTypes.func,
+  isSubmitting: PropTypes.bool
+}
+
+function mapStateToProps({ petitionCreateStore = {} }) {
+  return {
+    isSubmitting: petitionCreateStore.isSubmitting
+  }
+}
+
+export default connect(mapStateToProps)(EditUserForm)

--- a/src/components/theme-giraffe/edit-user-form.js
+++ b/src/components/theme-giraffe/edit-user-form.js
@@ -10,7 +10,7 @@ const inputStyle = {
 
 const EditUserForm = ({ user, handleSubmit, zip, onChangeZip, isSubmitting }) => (
   <form onSubmit={handleSubmit}>
-    { user.no_zip && (
+    {user.no_zip && (
       <input
         value={zip}
         onChange={onChangeZip}

--- a/src/components/theme-legacy/create-preview.js
+++ b/src/components/theme-legacy/create-preview.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router'
 
 import RegisterForm from '../../containers/register-form'
+import EditUserForm from '../theme-giraffe/edit-user-form'
 
 const getTargets = target => target.map(t => t.label || t.name).join(', ')
 
-export const CreatePreview = ({ petition, user, onSubmit }) => (
+export const CreatePreview = ({ petition, user, onSubmit, zip, onChangeZip }) => (
   <div className='container background-moveon-white bump-top-1'>
     <div className='container background-moveon-white bump-top-1'>
       <div className='row'>
@@ -32,14 +33,25 @@ export const CreatePreview = ({ petition, user, onSubmit }) => (
               </h1>
             </div>
 
-            {/* TODO: check user.authenticated and include a user update form (or just the launch button) */}
-            <RegisterForm
-              successCallback={onSubmit}
-              user={user}
-              includeZipAndPhone
-              useLaunchButton
-              useAlternateFields
-            />
+            {user && user.authenticated ? (
+              <EditUserForm
+                user={user}
+                handleSubmit={e => {
+                  e.preventDefault()
+                  onSubmit()
+                }}
+                zip={zip}
+                onChangeZip={onChangeZip}
+              />
+            ) : (
+              <RegisterForm
+                successCallback={onSubmit}
+                user={user}
+                includeZipAndPhone
+                useLaunchButton
+                useAlternateFields
+              />
+            )}
 
             <div className='bump-top-2 align-center percent-100'>
               <Link to='/create_revise.html' className='size-small'>
@@ -104,5 +116,7 @@ export const CreatePreview = ({ petition, user, onSubmit }) => (
 CreatePreview.propTypes = {
   petition: PropTypes.object,
   user: PropTypes.object,
-  onSubmit: PropTypes.func
+  onSubmit: PropTypes.func,
+  zip: PropTypes.string,
+  onChangeZip: PropTypes.func
 }

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -67,6 +67,8 @@ export class CreatePetition extends React.Component {
     if (!isCustom && !target.label) return // target is invalid
     if (!isCustom && this.state.target.find(old => old.label === target.label)) return // already exists
 
+    if (isCustom && !this.state.customInputs.name) return // Trying to add a blank custom target
+
     if (isCustom) {
       this.setState({ customInputs: { name: '', email: '', title: '' } })
     }

--- a/src/containers/create-preview.js
+++ b/src/containers/create-preview.js
@@ -12,6 +12,7 @@ import { CreatePreview as CreatePreviewComponent } from 'LegacyTheme/create-prev
 class CreatePreview extends React.Component {
   constructor(props) {
     super(props)
+    this.state = { zip: '' }
     this.submitPetition = this.submitPetition.bind(this)
   }
   componentDidMount() {
@@ -19,7 +20,7 @@ class CreatePreview extends React.Component {
   }
 
   submitPetition() {
-    return this.props.dispatch(Config.API_WRITABLE ? submit() : devLocalSubmit())
+    return this.props.dispatch(Config.API_WRITABLE ? submit(this.state.zip) : devLocalSubmit())
   }
 
   render() {
@@ -29,6 +30,8 @@ class CreatePreview extends React.Component {
         petition={this.props.petition}
         user={this.props.user}
         onSubmit={this.submitPetition}
+        zip={this.state.zip}
+        onChangeZip={e => this.setState({ zip: e.target.value })}
       />
     )
   }


### PR DESCRIPTION
Some of #552, where we deal with where the user is fully authenticated and does OR does not have a zip code.

I don't handle this yet, but I probably could in a similar way to the zip code: (once I get my local api working again)
>  if the user has an akid / guest login but is not authenticated, then we will also need to ask them to set a password, but don't need to ask name/etc

~I haven't tested with a real API yet, so if someone wants to test locally, that would be great.~ Now tested locally, and it seems to be working.