### PR TITLE
On signing, validate that the name is not an email address

### DIFF
--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -35,6 +35,7 @@ class SignatureAddForm extends React.Component {
     }
     this.validationFunction = {
       email: isValidEmail,
+      name: name => !isValidEmail(name), // See https://github.com/MoveOnOrg/mop-frontend/issues/560
       zip: zip => /(\d\D*){5}/.test(zip),
       phone: phone => /(\d\D*){10}/.test(phone) // 10-digits
     }


### PR DESCRIPTION
hopefully closes #560, but doesn't really get to the root of the problem as to why people are filling "name" with emails. I tried to reproduce in mobile safari, but couldn't.