### PR TITLE
WIP: Create petition tracking (theme-legacy)

### DIFF
--- a/docs/EXPLANATION--form-tracking.md
+++ b/docs/EXPLANATION--form-tracking.md
@@ -1,0 +1,120 @@
+<a name="FormTracker"></a>
+
+## FormTracker([params])
+A FormTracker instance gives the ability to keep analytics data for forms all in
+the same place, and provides methods for manipulating this analytics data (stored as
+internal state) as well as tracking this data to an analytics provider.
+
+Regenerate the markdown file for these docs with:
+`npx jsdoc-to-markdown src/lib/form-tracker.js > docs/EXPLANATION--form-tracking.md`
+(only edit these docs in form-tracker.js)
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [params] | <code>object</code> | an object of params (see below) |
+| [params.formvariant] | <code>string</code> | e.g. 'mobile' or 'desktop' |
+| [params.experiment] | <code>string</code> | name of the experiment being run |
+| [params.variationname] | <code>string</code> | the experiment group the user is in |
+
+
+* [FormTracker([params])](#FormTracker)
+    * [.submitForm([eventInfo])](#FormTracker+submitForm)
+    * [.formExpandTracker()](#FormTracker+formExpandTracker)
+    * [.formAdvanceTracker()](#FormTracker+formAdvanceTracker)
+    * [.setForm(ref, [variantname])](#FormTracker+setForm)
+    * [.updateFormProgress(eventInfo)](#FormTracker+updateFormProgress)
+    * [.validationErrorTracker()](#FormTracker+validationErrorTracker)
+    * [.getState()](#FormTracker+getState) ⇒ <code>object</code>
+    * [.setStateOnce(state)](#FormTracker+setStateOnce)
+
+<a name="FormTracker+submitForm"></a>
+
+### formTracker.submitForm([eventInfo])
+Should be called when the form is submitted to the server.
+Will send the current analytics data to segment.
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [eventInfo] | <code>object</code> | an object of additional state updates |
+
+<a name="FormTracker+formExpandTracker"></a>
+
+### formTracker.formExpandTracker()
+Should be called when a partially hidden form is expanded
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+<a name="FormTracker+formAdvanceTracker"></a>
+
+### formTracker.formAdvanceTracker()
+Should be called when the next section of multipart form is shown
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+<a name="FormTracker+setForm"></a>
+
+### formTracker.setForm(ref, [variantname])
+Saves a reference to the form (required for updateFormProgress()), saves the formLength and formvariant.
+Calls startForm, which sends the current analytics data to segment
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ref | <code>HTMLElement</code> | a reference to the actual form |
+| [variantname] | <code>string</code> | the varient name in the experiment, if it isn't ref.id |
+
+<a name="FormTracker+updateFormProgress"></a>
+
+### formTracker.updateFormProgress(eventInfo)
+Updates the internal form analytics data that will be tracked to segment
+when submitForm() is called. A good place to call is is onChange and onFocus
+of the input handlers.
+
+Call with eventInfo.fieldchanged when a field is changed or with
+eventinfo.fieldfocused when a field has been focused.
+
+Sets this field as lastfieldchanged and lastfieldfocused
+Sets fieldchanged/focused as the max of the previous and the specified field's index
+
+Will also call startForm() if needed
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| eventInfo | <code>object</code> | any updated tracking data |
+| [eventInfo.fieldchanged] | <code>string</code> | the name of the field changed |
+| [eventInfo.fieldfocused] | <code>string</code> | the name of the field focused |
+
+<a name="FormTracker+validationErrorTracker"></a>
+
+### formTracker.validationErrorTracker()
+Should be called when a form validation error is shown
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+<a name="FormTracker+getState"></a>
+
+### formTracker.getState() ⇒ <code>object</code>
+Returns the internal state of this FormTracker instance, suitable for
+saving (e.g. for a multipart form) and reloading with setStateOnce()
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+**Returns**: <code>object</code> - the internal state  
+<a name="FormTracker+setStateOnce"></a>
+
+### formTracker.setStateOnce(state)
+Sets the FormTracker's internal state, (e.g. after resuming a multipart form).
+you can get this state from getState()
+
+Internally remembers the state has been set, so it's safe to call multiple times
+(e.g. various lifecycle methods), if it is unclear when your data will be loaded (redux)
+
+**Kind**: instance method of [<code>FormTracker</code>](#FormTracker)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| state | <code>object</code> | the internal state to set |
+

--- a/src/actions/createPetitionActions.js
+++ b/src/actions/createPetitionActions.js
@@ -20,7 +20,8 @@ export function previewSubmit({
   target,
   source,
   clonedFromId,
-  solicitId
+  solicitId,
+  trackingState
 }) {
   return {
     type: actionTypes.CREATE_PETITION_PREVIEW_SUBMIT,
@@ -30,7 +31,8 @@ export function previewSubmit({
     target,
     source,
     clonedFromId,
-    solicitId
+    solicitId,
+    trackingState
   }
 }
 

--- a/src/components/theme-legacy/create-petition-form.js
+++ b/src/components/theme-legacy/create-petition-form.js
@@ -23,6 +23,7 @@ const CreatePetitionForm = ({
   selected,
   setSelected,
   instructionStyle,
+  setFormRef,
   setRef,
   errors,
   onChange,
@@ -42,7 +43,7 @@ const CreatePetitionForm = ({
     <div className='container'>
       <div className='row'>
         <div className='background-moveon-light-gray span6 start-form'>
-          <form id='petition_form' onSubmit={onPreview}>
+          <form id='petition_form' ref={setFormRef} onSubmit={onPreview}>
             <ul className='errors'>
               {errors.map(err => <li key={err}>{err}</li>)}
             </ul>
@@ -135,6 +136,7 @@ CreatePetitionForm.propTypes = {
   selected: PropTypes.string,
   setSelected: PropTypes.func,
   instructionStyle: PropTypes.object,
+  setFormRef: PropTypes.func,
   setRef: PropTypes.func,
   errors: PropTypes.array.isRequired,
   onChange: PropTypes.func,

--- a/src/components/theme-legacy/create-preview.js
+++ b/src/components/theme-legacy/create-preview.js
@@ -7,7 +7,7 @@ import EditUserForm from 'LegacyTheme/edit-user-form'
 
 const getTargets = target => target.map(t => t.label || t.name).join(', ')
 
-export const CreatePreview = ({ petition, user, onSubmit, zip, onChangeZip }) => (
+export const CreatePreview = ({ petition, user, onSubmit, zip, onChangeZip, formTracker }) => (
   <div className='container background-moveon-white bump-top-1'>
     <div className='container background-moveon-white bump-top-1'>
       <div className='row'>
@@ -47,6 +47,7 @@ export const CreatePreview = ({ petition, user, onSubmit, zip, onChangeZip }) =>
               <RegisterForm
                 successCallback={onSubmit}
                 user={user}
+                formTracker={formTracker}
                 isCreatingPetition
                 includeZipAndPhone
                 useLaunchButton
@@ -119,5 +120,6 @@ CreatePreview.propTypes = {
   user: PropTypes.object,
   onSubmit: PropTypes.func,
   zip: PropTypes.string,
-  onChangeZip: PropTypes.func
+  onChangeZip: PropTypes.func,
+  formTracker: PropTypes.object
 }

--- a/src/components/theme-legacy/register-form.js
+++ b/src/components/theme-legacy/register-form.js
@@ -11,14 +11,16 @@ const RegisterForm = ({
   errorList,
   handleSubmit,
   setRef,
+  setFormRef,
   isSubmitting,
   includeZipAndPhone,
   useLaunchButton,
-  useAlternateFields
+  useAlternateFields,
+  onChangeTracking
 }) => (
   <React.Fragment>
     <ul className='errors'>{errorList && errorList()}</ul>
-    <form method='POST' onSubmit={handleSubmit} className='form-horizontal'>
+    <form method='POST' ref={setFormRef} onSubmit={handleSubmit} className='form-horizontal'>
       <input
         ref={setRef}
         name='name'
@@ -27,6 +29,7 @@ const RegisterForm = ({
         id='inputName'
         placeholder='Name'
         style={useAlternateFields ? inputStyle : {}}
+        onChange={onChangeTracking}
       />
       <input
         ref={setRef}
@@ -36,6 +39,7 @@ const RegisterForm = ({
         id='inputEmail'
         placeholder='Email'
         style={useAlternateFields ? inputStyle : {}}
+        onChange={onChangeTracking}
       />
       {includeZipAndPhone && (
         <input
@@ -45,6 +49,7 @@ const RegisterForm = ({
           type='text'
           placeholder='Phone (optional)'
           style={useAlternateFields ? inputStyle : {}}
+          onChange={onChangeTracking}
         />
       )}
       {includeZipAndPhone && (
@@ -55,6 +60,7 @@ const RegisterForm = ({
           type='text'
           placeholder='ZIP Code'
           style={useAlternateFields ? inputStyle : {}}
+          onChange={onChangeTracking}
         />
       )}
       <input
@@ -65,6 +71,7 @@ const RegisterForm = ({
         id='inputPassword'
         placeholder='Password'
         style={useAlternateFields ? inputStyle : {}}
+        onChange={onChangeTracking}
       />
       <input
         name='passwordConfirm'
@@ -74,6 +81,7 @@ const RegisterForm = ({
         id='inputConfirm'
         placeholder='Confirm Password'
         style={useAlternateFields ? inputStyle : {}}
+        onChange={onChangeTracking}
       />
       <div>
         <div className='bump-bottom-2'>
@@ -104,10 +112,12 @@ RegisterForm.propTypes = {
   errorList: PropTypes.func,
   handleSubmit: PropTypes.func,
   setRef: PropTypes.func,
+  setFormRef: PropTypes.func,
   isSubmitting: PropTypes.bool,
   includeZipAndPhone: PropTypes.bool,
   useLaunchButton: PropTypes.bool,
-  useAlternateFields: PropTypes.bool
+  useAlternateFields: PropTypes.bool,
+  onChangeTracking: PropTypes.func
 }
 
 export default RegisterForm

--- a/src/containers/create-petition.js
+++ b/src/containers/create-petition.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
 import { appLocation } from '../routes'
+import { FormTracker } from '../lib'
 import { previewSubmit } from '../actions/createPetitionActions'
 
 import CreatePetitionForm from 'LegacyTheme/create-petition-form'
@@ -40,6 +41,7 @@ export class CreatePetition extends React.Component {
     this.onTargetAdd = this.onTargetAdd.bind(this)
     this.onTargetRemove = this.onTargetRemove.bind(this)
     this.validateAndContinue = this.validateAndContinue.bind(this)
+    this.formTracker = new FormTracker()
   }
 
   onPreview(event) {
@@ -98,6 +100,7 @@ export class CreatePetition extends React.Component {
 
   validateAndContinue() {
     if (this.formIsValid()) {
+      this.formTracker.formAdvanceTracker()
       this.props.dispatch(
         previewSubmit({
           title: this.state.title,
@@ -106,7 +109,8 @@ export class CreatePetition extends React.Component {
           description: this.state.description,
           source: this.state.source,
           clonedFromId: this.state.clonedFromId,
-          solicitId: this.state.solicitId
+          solicitId: this.state.solicitId,
+          trackingState: this.formTracker.getState()
         })
       )
       appLocation.push('/create_preview.html')
@@ -152,12 +156,14 @@ export class CreatePetition extends React.Component {
         <CreatePetitionForm
           setSelected={this.setSelected}
           setRef={this.setRef}
+          setFormRef={ref => { this.form = ref }}
           selected={this.state.selected}
           instructionStyle={instructionStyle}
           errors={this.state.errors}
-          onChange={({ target: { name, value } }) =>
+          onChange={({ target: { name, value } }) => {
             this.setState({ [name]: value })
-          }
+            this.formTracker.updateFormProgress({ fieldchanged: name })
+          }}
           onPreview={this.onPreview}
           title={this.state.title}
           summary={this.state.summary}

--- a/src/containers/create-preview.js
+++ b/src/containers/create-preview.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import Config from '../config'
+import { FormTracker } from '../lib'
 import { appLocation } from '../routes'
 
 import { submit, devLocalSubmit } from '../actions/createPetitionActions'
@@ -14,12 +15,20 @@ class CreatePreview extends React.Component {
     super(props)
     this.state = { zip: '' }
     this.submitPetition = this.submitPetition.bind(this)
+    this.formTracker = new FormTracker()
+    this.formTracker.setStateOnce(props.trackingState)
   }
+
   componentDidMount() {
     if (!this.props.hasPetition) appLocation.push('/create_start.html')
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.formTracker.setStateOnce(nextProps.trackingState)
+  }
+
   submitPetition() {
+    this.formTracker.submitForm()
     return this.props.dispatch(Config.API_WRITABLE ? submit(this.state.zip) : devLocalSubmit())
   }
 
@@ -32,6 +41,7 @@ class CreatePreview extends React.Component {
         onSubmit={this.submitPetition}
         zip={this.state.zip}
         onChangeZip={e => this.setState({ zip: e.target.value })}
+        formTracker={this.formTracker}
       />
     )
   }
@@ -41,7 +51,8 @@ CreatePreview.propTypes = {
   hasPetition: PropTypes.bool,
   petition: PropTypes.object,
   user: PropTypes.object,
-  dispatch: PropTypes.func
+  dispatch: PropTypes.func,
+  trackingState: PropTypes.object
 }
 
 function mapStateToProps({ petitionCreateStore, userStore }) {
@@ -52,6 +63,7 @@ function mapStateToProps({ petitionCreateStore, userStore }) {
       !petitionCreateStore.submitted
     ),
     petition: petitionCreateStore,
+    trackingState: petitionCreateStore.trackingState,
     user: userStore
   }
 }

--- a/src/containers/register-form.js
+++ b/src/containers/register-form.js
@@ -18,6 +18,12 @@ class Register extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this)
     this.validateForm = this.validateForm.bind(this)
     this.errorList = this.errorList.bind(this)
+    this.onChangeTracking = this.onChangeTracking.bind(this)
+  }
+
+  componentDidMount() {
+    if (!this.props.formTracker) return
+    this.props.formTracker.setForm(this.form)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -26,6 +32,14 @@ class Register extends React.Component {
       this.password.value = ''
       this.passwordConfirm.value = ''
     }
+  }
+
+  onChangeTracking(e) {
+    // just to handle tracking of inputs
+    // user data will be read from refs
+    const { formTracker } = this.props
+    if (!formTracker) return
+    formTracker.updateFormProgress({ fieldchanged: e.target.name })
   }
 
   /**
@@ -59,6 +73,7 @@ class Register extends React.Component {
     }
     if (errors.length) {
       this.setState({ presubmitErrors: errors })
+      if (this.props.formTracker) this.props.formTracker.validationErrorTracker()
     }
     return !errors.length
   }
@@ -101,10 +116,12 @@ class Register extends React.Component {
         handleSubmit={this.handleSubmit}
         // eslint-disable-next-line no-return-assign
         setRef={input => input && (this[input.name] = input)}
+        setFormRef={ref => { this.form = ref }}
         isSubmitting={this.props.isSubmitting}
         includeZipAndPhone={this.props.includeZipAndPhone}
         useLaunchButton={this.props.useLaunchButton}
         useAlternateFields={this.props.useAlternateFields}
+        onChangeTracking={this.onChangeTracking}
       />
     )
   }
@@ -123,7 +140,8 @@ Register.propTypes = {
   useLaunchButton: PropTypes.bool,
   useAlternateFields: PropTypes.bool,
   successCallback: PropTypes.func,
-  isCreatingPetition: PropTypes.bool
+  isCreatingPetition: PropTypes.bool,
+  formTracker: PropTypes.object
 }
 
 function mapStateToProps({ userStore = {}, petitionCreateStore = {} }) {

--- a/src/lib/form-tracker.js
+++ b/src/lib/form-tracker.js
@@ -167,6 +167,22 @@ export function FormTracker({ experiment = '', formvariant = '', variationname =
   this.getState = function getState() {
     return this.state
   }
+
+  /**
+   * Sets the FormTracker's internal state, (e.g. after resuming a multipart form).
+   * you can get this state from getState()
+   *
+   * Internally remembers the state has been set, so it's safe to call multiple times
+   * (e.g. various lifecycle methods), if it is unclear when your data will be loaded (redux)
+   * @param {object} state - the internal state to set
+   */
+  this.setStateOnce = function setStateOnce(state) {
+    if (state && !this.options.setStateCalled) {
+      this.state = { ...state }
+      this.options.setStateCalled = true
+    }
+  }
+
   /**
    * @private
    * Tracks the internal state to segment
@@ -180,6 +196,7 @@ export function FormTracker({ experiment = '', formvariant = '', variationname =
     }
     if (Config.FAKE_ANALYTICS) {
       console.log(`Tracking event ${eventName} with current state object: ${JSON.stringify(this.state)} `)
+      // console.log(`INSERT INTO tracking_test (eventname,${Object.keys(this.state).join(',')}) VALUES ("${eventName}",${Object.values(this.state).map(JSON.stringify).join(',')})`)
     }
   }
 }

--- a/src/reducers/petition-create.js
+++ b/src/reducers/petition-create.js
@@ -12,7 +12,8 @@ const reducer = (state = {}, action) => {
         target: action.target,
         source: action.source,
         cloned_from_id: action.clonedFromId,
-        solicit_id: action.solicitId
+        solicit_id: action.solicitId,
+        trackingState: action.trackingState
       }
     case actionTypes.CREATE_PETITION_REQUEST:
       return {


### PR DESCRIPTION
Here I'm starting to use FormTracker to track the theme-legacy create-petition.

It becomes a bit complicated because this is a multistep form, each with separate routes. I solved this by adding a few methods to the tracker to save and load the state from the previous step (for simplicity, handled manually in the component). So it won't track `form_finished` until the petition is actually created.

It seems like this might be an okay way of comparing between the petition creation methods: which one has a better success rate (`total completed`/`total started`), but I'm sure there are complexities I'm not thinking of.

I also utilize the tracker state var `sectionadvanced`, so we'll theoretically be able to know where they were on the multistep form with the combination of `fieldchanged` (where the index resets for the next step) and `sectionadvance` (which will be 0 for the first step and 1 for the second) (really only relevant once bounce tracking is working). But there might be a better way of doing this.

I was also playing around with the idea of creating components like `TrackedForm` and `TrackedInput` to hide all of this complexity and call into formTracker automatically, but not sure if that is where I should be spending my time.

Here's what would get tracked
```
{  
   "result":"completed",
   "variationname":"",
   "formvariant":"",
   "experiment":"",
   "loginstate":0,
   "validationerror":0,
   "formexpand":0,
   "sectionadvanced":1,
   "fieldfocused":-1,
   "fieldchanged":5,
   "lastfieldchanged":"passwordConfirm",
   "lastfieldfocused":"passwordConfirm",
   "formLength":7
}
```

TODO:
- [ ] loginstate tracking
- [ ] full form tracking for logged in state?
- [ ] track the other creation forms when they are ready, and set up an experiment

Let me know if you have any thoughts.