### PR TITLE
Allows someone to add sms in qs in order to add random cohort

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -100,7 +100,7 @@ export const routes = store => {
         // makes sure it only does it on sign pages and
         // only triggers if you land directly on sign page vs through source
         // checks if there is a cohort already in the querystring so it doesnt add another cohort
-        if (pathName.search('sign') > -1 && queryString.search('cohort') === -1) {
+        if (pathName.search('sign') > -1 && queryString.search('cohort') === -1 && queryString.search('sms') > -1) {
           const preChar = /\?/.test(currentLocation.search) ? '&' : '?'
           browserHistory.push(`${pathName}${currentLocation.search}${preChar}cohort=${cohort}`)
         }

--- a/src/routes.js
+++ b/src/routes.js
@@ -100,7 +100,7 @@ export const routes = store => {
         // makes sure it only does it on sign pages and
         // only triggers if you land directly on sign page vs through source
         // checks if there is a cohort already in the querystring so it doesnt add another cohort
-        if (pathName.search('sign') > -1 && queryString.search('cohort') === -1 && queryString.search('sms') > -1) {
+        if (/sign/.test(pathName) && /sms/.test(queryString) && !/cohort/.test(queryString)) {
           const preChar = /\?/.test(currentLocation.search) ? '&' : '?'
           browserHistory.push(`${pathName}${currentLocation.search}${preChar}cohort=${cohort}`)
         }


### PR DESCRIPTION
In order to test on FB, or per petition, we need the ability to trigger it per petition vs per all petitions. I suggest adding 'sms' in the querystring (could even appear as `source=sms`) in order to enable random cohort rendering. 