### PR TITLE
update webpack-cli after getting build error on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
     "sinon": "^5.0.2",
     "style-loader": "^0.21.0",
     "svg-react-loader": "^0.4.5",
-    "webpack": "^4.12.0",
+    "webpack": "^4.20.2",
     "webpack-bundle-analyzer": "^2.11.1",
-    "webpack-cli": "^2.1.5",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.4"
   }
 }


### PR DESCRIPTION
https://github.com/plotly/dash-component-boilerplate/issues/12

`TypeError: Cannot read property 'properties' of undefined `