### PR TITLE
Suggest common domains with typos

### DIFF
--- a/src/components/theme-giraffe/signature-add-form.js
+++ b/src/components/theme-giraffe/signature-add-form.js
@@ -50,6 +50,7 @@ const SignatureAddForm = ({
           label='Name*'
           setRef={setRef}
           onChange={updateStateFromValue('name')}
+          onBlur={updateStateFromValue('name', false, /* validateNow= */ true)}
         />
         {validationError('name')}
         <InputBlock
@@ -57,6 +58,7 @@ const SignatureAddForm = ({
           name='email'
           label='Email*'
           onChange={updateStateFromValue('email')}
+          onBlur={updateStateFromValue('email', false, /* validateNow= */ true)}
         />
         {validationError('email')}
       </div>

--- a/src/containers/signature-add-form.js
+++ b/src/containers/signature-add-form.js
@@ -132,12 +132,23 @@ class SignatureAddForm extends React.Component {
   }
 
   validationError(key) {
-    if (this.state.validationTried) {
-      if (Object.keys(this.state.required).indexOf(key) > -1) {
-        const func = this.validationFunction[key]
-        if (!this.state[key] || (func && !func(String(this.state[key])))) {
+    if (this.state.validationTried || this.state[`${key}Validated`]) {
+      const validFunc = this.validationFunction[key]
+      if (!this.state[key]) {
+        if (key in this.state.required) {
           return (
             <div className='alert alert-danger red' role='alert'>{this.state.required[key]}</div>
+          )
+        }
+      } else if (validFunc) {
+        const isValid = validFunc(String(this.state[key]))
+        if (isValid === false) {
+          return (
+            <div className='alert alert-danger red' role='alert'>Invalid input for {key}</div>
+          )
+        } else if (isValid && isValid.warning) {
+          return (
+            <div className='alert alert-danger red' role='alert'>{isValid.warning}</div>
           )
         }
       }
@@ -155,7 +166,7 @@ class SignatureAddForm extends React.Component {
     ).reduce((a, b) => a && b, true)
   }
 
-  updateStateFromValue(field, isCheckbox = false) {
+  updateStateFromValue(field, isCheckbox = false, validateNow = false) {
     return event => {
       const value = isCheckbox ? event.target.checked : event.target.value
       if (this.state[field] !== value) {
@@ -169,6 +180,9 @@ class SignatureAddForm extends React.Component {
         [field]: value,
         hideUntilInteract: false // show some hidden fields if they are hidden
       })
+      if (validateNow && value && this.validationFunction[field]) {
+        this.setState({ [`${field}Validated`]: true })
+      }
     }
   }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -116,13 +116,14 @@ try { RegExp('\\w', 'iu') } catch (err) { supportsUnicode = false }
 const userRegex = RegExp('^[-!#$%&\'*+/=?^_`{}|~\\w]+(\\.[-!#$%&\'*+/=?^_`{}|~\\w]+)*$', supportsUnicode ? 'iu' : 'i')
 const quotedUserRegex = /^"([\001-\010\013\014\016-\037!#-[\]-\177]|\\[\001-\011\013\014\016-\177])*"$/i
 const domainRegex = /^((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+)(?:[A-Z0-9-]{1,62}[A-Z0-9])$/i
-const commonDomains = ['aol.com', 'comcast.net', 'gmail.com', 'hotmail.com', 'verizon.net', 'yahoo.com']
+const commonDomains = ['aol.com', 'comcast.net', 'gmail.com', 'hotmail.com',
+                       'icloud.com', 'outlook.com', 'verizon.net', 'yahoo.com']
 
 export const isValidEmail = email => {
   if (!email) { return false }
   const parts = email.split('@')
   if (parts.length !== 2) { return false }
-  const domain = parts[1]
+  const domain = parts[1].toLowerCase()
   if (!((userRegex.test(parts[0]) || quotedUserRegex.test(parts[0]))
         && domainRegex.test(domain))) {
     return false

--- a/test/components/signature-add-form.js
+++ b/test/components/signature-add-form.js
@@ -414,10 +414,14 @@ describe('<SignatureAddForm />', () => {
     forEach([ // Valid emails
       'foo@example.com',
       'foo.bar@example.com',
+      'foo.bar@gnail.com',
       'c\u017Fsaire@example.com',
       'foo@gmail.edu.ca'
     ]).it('valid email %s', goodEmail => {
-      expect(isValidEmail(goodEmail)).to.be.equal(true)
+      expect(isValidEmail(goodEmail).validEmail).to.be.equal(true)
+      if (goodEmail === 'foo.bar@gnail.com') {
+        expect(isValidEmail(goodEmail).warning).to.be.equal('Did you mean gmail.com?')
+      }
     })
     forEach([ // Invalid emails
       'foo@example..com',


### PR DESCRIPTION
This is to reduce errors when people enter their email address and sometimes have a typo in the domain name.

This adds immediate feedback for the name and email fields (rather than waiting for submitting) and in the case of an 'off-by-1' difference for common domains, we suggest the more common domain in red (but don't block submission)

![petitionemailsuggest](https://user-images.githubusercontent.com/52117/50015149-bc6d9480-ffbd-11e8-9aec-327bbb692763.png)
