### PR TITLE
595 messenger share wo whatsapp

### DIFF
--- a/docs/REFERENCE--environment_variables.md
+++ b/docs/REFERENCE--environment_variables.md
@@ -19,3 +19,4 @@ LOCAL_REACT                       | Dev only: a path with react.js and react-dom
 LOCAL_CSS                         | Dev only: a theme-giraffe style.css. E.g. `http://localhost:3000/styles/main.css`, as served by `gulp watch` in the giraffe repo, so you can change css and/or develop offline. _Default_: Loads css from the mop-static-stage s3 bucket
 AB_TEST_ENABLED                   | When set to an integer, enables AB test
 FAKE_ANALYTICS                    | Dev only: set to true if window.analytics isnt exposed from backend server
+MESSENGER_APP_ID                  | Necessary in order to create deep link for Messenger share button after signing

--- a/src/components/theme-giraffe/messenger-button.js
+++ b/src/components/theme-giraffe/messenger-button.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { withMessenger } from '../../containers/hoc-messenger'
+import MessengerSvg from 'GiraffeUI/svgs/messenger.svg'
+
+const MessengerButton = ({ onClick }) => (
+  <a className='petition-thanks__cta d-lg-none' onClick={onClick}>
+    <MessengerSvg />
+    Share on Messenger
+  </a>
+)
+
+MessengerButton.propTypes = {
+  onClick: PropTypes.func
+}
+
+export default withMessenger(MessengerButton)

--- a/src/components/theme-giraffe/thanks.js
+++ b/src/components/theme-giraffe/thanks.js
@@ -8,9 +8,8 @@ const Thanks = ({
   isCreator,
   renderRawLink,
   renderTwitter,
-  renderWhatsAppLink,
-  renderWhatsAppButton,
   renderFacebook,
+  renderMessenger,
   renderMail,
   renderCopyPaste,
   nextPetition
@@ -30,8 +29,8 @@ const Thanks = ({
 
         <div className='petition-thanks__cta-group'>
           {renderMail()}
-          {renderWhatsAppButton()}
           {renderFacebook()}
+          {renderMessenger()}
         </div>
 
         <p>Or copy and paste the text below into a message:</p>
@@ -40,7 +39,6 @@ const Thanks = ({
 
         <div className='petition-thanks__links'>
           {renderTwitter()}
-          {renderWhatsAppLink()}
           {renderRawLink()}
         </div>
       </div>
@@ -53,8 +51,7 @@ Thanks.propTypes = {
   isCreator: PropTypes.bool,
   renderTwitter: PropTypes.func,
   renderFacebook: PropTypes.func,
-  renderWhatsAppButton: PropTypes.func,
-  renderWhatsAppLink: PropTypes.func,
+  renderMessenger: PropTypes.func,
   renderMail: PropTypes.func,
   renderCopyPaste: PropTypes.func,
   renderRawLink: PropTypes.func,

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ export const Config = {
   STATIC_ROOT: process.env.STATIC_ROOT,
   WORDPRESS_API_URI: process.env.WORDPRESS_API_URI,
   AB_TEST_ENABLED: process.env.AB_TEST_ENABLED,
-  FAKE_ANALYTICS: process.env.FAKE_ANALYTICS
+  FAKE_ANALYTICS: process.env.FAKE_ANALYTICS,
+  MESSENGER_APP_ID: process.env.MESSENGER_APP_ID
 }
 export default Config

--- a/src/containers/hoc-messenger.js
+++ b/src/containers/hoc-messenger.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { petitionShortCode } from '../lib'
+import Config from '../config'
+
+
+function getMobileMessengerLink(encodedValue) {
+  // testing messenger link on mobile only first
+ return `fb-messenger://share?link=${encodedValue}&app_id=${encodeURIComponent(Config.MESSENGER_APP_ID)}`
+}
+
+export function withMessenger(WrappedComponent) {
+  class Messenger extends React.Component {
+    constructor(props) {
+      super(props)
+      this.getShareLink = this.getShareLink.bind(this)
+      this.shareMessenger = this.shareMessenger.bind(this)
+    }
+
+    getShareLink() {
+      const { shortLinkMode, shortLinkArgs } = this.props
+      const messengerShareLink = petitionShortCode(
+        shortLinkMode,
+        ...shortLinkArgs
+      )
+      return messengerShareLink
+    }
+
+    shareMessenger() {
+      /* open this window in case user does not have messenger installed */
+      // takes them to moveon page but doesnt include info on petition
+      const encodedValue = encodeURIComponent(this.getShareLink())
+      const shareLink = getMobileMessengerLink(encodedValue)
+      window.open(shareLink)
+      setTimeout(() => { window.open('https://m.me/moveon') }, 3000)
+      const { recordShare, afterShare } = this.props
+      if (recordShare) recordShare()
+      if (afterShare) afterShare()
+    }
+
+    render() {
+      /* eslint-disable no-unused-vars */
+      // remove props we don't want to pass through
+      const {
+        petition,
+        shortLinkMode,
+        shortLinkArgs,
+        recordShare,
+        // (just to remove from otherProps)
+        ...otherProps
+      } = this.props
+      /* eslint-enable */
+      return <WrappedComponent {...otherProps} onClick={this.shareMessenger} />
+    }
+  }
+  Messenger.propTypes = {
+    petition: PropTypes.object,
+    shortLinkArgs: PropTypes.array,
+    shortLinkMode: PropTypes.string,
+    recordShare: PropTypes.func,
+    afterShare: PropTypes.func
+  }
+  return Messenger
+}

--- a/src/containers/hoc-messenger.js
+++ b/src/containers/hoc-messenger.js
@@ -23,14 +23,19 @@ export function withMessenger(WrappedComponent) {
         shortLinkMode,
         ...shortLinkArgs
       )
-      return messengerShareLink
+      const encodedLink = encodeURIComponent(messengerShareLink)
+      return encodedLink
     }
 
     shareMessenger() {
-      /* open this window in case user does not have messenger installed */
-      // takes them to moveon page but doesnt include info on petition
-      const encodedValue = encodeURIComponent(this.getShareLink())
-      const shareLink = getMobileMessengerLink(encodedValue)
+      /* If the app is installed:
+        - User will be brought to the app with the petition
+        - The second timeout will still be called and the moveon messenger page will open in a window
+        If the app is not installed:
+        - The first window.open call will fail and error
+        - The second timeout will still be called and the moveon messenger page will open in a window
+        - The second window.open call is for users without the app installed */
+      const shareLink = getMobileMessengerLink(this.getShareLink())
       window.open(shareLink)
       setTimeout(() => { window.open('https://m.me/moveon') }, 3000)
       const { recordShare, afterShare } = this.props

--- a/src/containers/thanks.js
+++ b/src/containers/thanks.js
@@ -151,13 +151,13 @@ class Thanks extends React.Component {
   renderMessenger() {
     const isMobile = /iPhone/.test(navigator.userAgent) || /Android/.test(navigator.userAgent)
     return (isMobile && this.state.messenger && Config.MESSENGER_APP_ID ?
-     <MessengerButton
-       petition={this.props.petition}
-       shortLinkMode={this.props.isCreator ? 'd' : 'a'}
-       shortLinkArgs={this.shortLinkArgs}
-       recordShare={this.recordShare('messenger', `${this.state.pre}.me`)}
-       afterShare={() => this.setState({ sharedSocially: true })}
-     />
+      <MessengerButton
+        petition={this.props.petition}
+        shortLinkMode={this.props.isCreator ? 'd' : 'a'}
+        shortLinkArgs={this.shortLinkArgs}
+        recordShare={this.recordShare('messenger', `${this.state.pre}.me`)}
+        afterShare={() => this.setState({ sharedSocially: true })}
+      />
      : '')
    }
 

--- a/src/containers/thanks.js
+++ b/src/containers/thanks.js
@@ -149,7 +149,7 @@ class Thanks extends React.Component {
   }
 
   renderMessenger() {
-    const isMobile = /iPhone/.test(navigator.userAgent) || /Android/.test(navigator.userAgent)
+    const isMobile = /iPhone|iPad|Android/.test(navigator.userAgent)
     return (isMobile && this.state.messenger && Config.MESSENGER_APP_ID ?
       <MessengerButton
         petition={this.props.petition}

--- a/src/containers/thanks.js
+++ b/src/containers/thanks.js
@@ -10,6 +10,7 @@ import TwitterButton from 'Theme/twitter-button'
 import FacebookButton from 'Theme/facebook-button'
 import WhatsAppButton from 'GiraffeTheme/whatsapp-button'
 import WhatsAppLink from 'GiraffeTheme/whatsapp-link'
+import MessengerButton from 'GiraffeTheme/messenger-button'
 import MailButton from 'Theme/mail-button'
 import CopyPaste from 'Theme/copy-paste'
 import RawLink from 'Theme/raw-link'
@@ -54,20 +55,22 @@ class Thanks extends React.Component {
     this.state = {
       sharedSocially: false,
       pre: getPre(fromSource, petition, this.props.isCreator),
-      whatsApp: (user && user.cohort === 1)
+      whatsApp: false, // need to hide whatsapp button during messenger test
+      messenger: (user && user.cohort === 1)
     }
 
     this.recordShare = this.recordShare.bind(this)
     this.renderTwitter = this.renderTwitter.bind(this)
     this.renderFacebook = this.renderFacebook.bind(this)
+    this.renderMessenger = this.renderMessenger.bind(this)
     this.renderMail = this.renderMail.bind(this)
     this.renderCopyPaste = this.renderCopyPaste.bind(this)
     this.renderRawLink = this.renderRawLink.bind(this)
     this.renderWhatsAppLink = this.renderWhatsAppLink.bind(this)
     this.renderWhatsAppButton = this.renderWhatsAppButton.bind(this)
     this.cohortTracker = new CohortTracker({
-      experiment: 'whatsAppShare2',
-      variationname: (this.state.whatsApp ? 'cohort1' : 'current'),
+      experiment: 'messenger2',
+      variationname: (this.state.messenger ? 'cohort1' : 'current'),
       userinfo: this.trackingParams // sending the user signon id or sig hash to identify them
     })
   }
@@ -76,9 +79,8 @@ class Thanks extends React.Component {
     if (!this.props.nextPetitionsLoaded && !this.props.isCreator) {
       this.props.dispatch(petitionActions.loadTopPetitions(this.props.petition.entity === 'pac' ? 1 : 0, '', false))
     }
-    if (this.props.user && this.props.user.cohort) {
-      this.cohortTracker.track('whatsapp')
-    }
+
+    if (this.props.user && this.props.user.cohort) this.cohortTracker.track('messenger')
   }
 
   recordShare(medium, source) {
@@ -146,6 +148,19 @@ class Thanks extends React.Component {
     )
   }
 
+  renderMessenger() {
+    const isMobile = /iPhone/.test(navigator.userAgent) || /Android/.test(navigator.userAgent)
+    return (isMobile && this.state.messenger && Config.MESSENGER_APP_ID ?
+     <MessengerButton
+       petition={this.props.petition}
+       shortLinkMode={this.props.isCreator ? 'd' : 'a'}
+       shortLinkArgs={this.shortLinkArgs}
+       recordShare={this.recordShare('messenger', `${this.state.pre}.me`)}
+       afterShare={() => this.setState({ sharedSocially: true })}
+     />
+     : '')
+   }
+
   renderMail() {
     return (
       <MailButton
@@ -201,6 +216,7 @@ class Thanks extends React.Component {
         renderWhatsAppLink={this.renderWhatsAppLink}
         renderWhatsAppButton={this.renderWhatsAppButton}
         renderFacebook={this.renderFacebook}
+        renderMessenger={this.renderMessenger}
         renderMail={this.renderMail}
         renderCopyPaste={this.renderCopyPaste}
         renderRawLink={this.renderRawLink}

--- a/src/giraffe-ui/svgs/messenger.svg
+++ b/src/giraffe-ui/svgs/messenger.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g id="surface1">
+	<path d="M25,2C12.3,2,2,11.6,2,23.5c0,6.5,3.1,12.3,8,16.2v8.9l1.5-0.8l7.2-3.8c2,0.5,4.1,0.9,6.3,0.9
+		c12.7,0,23-9.6,23-21.5S37.7,2,25,2z M25,4c11.6,0,21,8.8,21,19.5S36.6,43,25,43c-2.2,0-4.3-0.3-6.2-0.9L18.4,42l-0.3,0.2L12,45.4
+		v-6.6l-0.4-0.3C7,34.9,4,29.5,4,23.5C4,12.8,13.4,4,25,4z M22.7,17.7l-12,12.8l10.8-6.1l5.8,6.2l11.9-12.9l-10.5,5.9L22.7,17.7z"/>
+</g>
+</svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,8 @@ var envVars = {
   'TRACK_SHARE_URL': process.env.TRACK_SHARE_URL || '',
   'USE_HASH_BROWSING': process.env.USE_HASH_BROWSING || false,
   'PROD': process.env.PROD,
-  'AB_TEST_ENABLED': process.env.AB_TEST_ENABLED || false
+  'AB_TEST_ENABLED': process.env.AB_TEST_ENABLED || false,
+  'MESSENGER_APP_ID': process.env.MESSENGER_APP_ID,
 }
 
 // Stringify all envVars so strings get quoted (i.e. not included as code)


### PR DESCRIPTION
I need to take the whatsapp button out to test the messenger button separately; some notes below:
- This contains a lot of the logic in #606 
- This doesn't completely rip out whatsapp work because we're still making a decision about whether to keep testing the button. There's a scenario where we could still test messenger and whatsapp.
- This changes the experiment to `messenger2` and populates the messenger table for testing
- This button only appears on mobile when cohort=1

Screen Shot on Mobile:
<img width="477" alt="Screen Shot 2019-05-02 at 11 27 31 AM" src="https://user-images.githubusercontent.com/16676323/57087224-96773100-6ccd-11e9-9b09-ff1e642148a2.png">
