### PR TITLE
Add branded color test

### DIFF
--- a/src/components/theme-giraffe/facebook-button.js
+++ b/src/components/theme-giraffe/facebook-button.js
@@ -3,16 +3,18 @@ import PropTypes from 'prop-types'
 
 import { withFacebook } from '../../containers/hoc-facebook'
 import FacebookSvg from 'GiraffeUI/svgs/facebook.svg'
+import { addBrandedColorClass } from '../../lib'
 
-const FacebookButton = ({ onClick }) => (
-  <a className='petition-thanks__cta' onClick={onClick}>
+const FacebookButton = ({ onClick, cohort }) => (
+  <a className={`petition-thanks__cta ${addBrandedColorClass('facebook', cohort)}`} onClick={onClick}>
     <FacebookSvg />
     Share on Facebook
   </a>
 )
 
 FacebookButton.propTypes = {
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  cohort: PropTypes.bool
 }
 
 export default withFacebook(FacebookButton)

--- a/src/components/theme-giraffe/messenger-button.js
+++ b/src/components/theme-giraffe/messenger-button.js
@@ -3,16 +3,18 @@ import PropTypes from 'prop-types'
 
 import { withMessenger } from '../../containers/hoc-messenger'
 import MessengerSvg from 'GiraffeUI/svgs/messenger.svg'
+import { addBrandedColorClass } from '../../lib'
 
-const MessengerButton = ({ onClick }) => (
-  <a className='petition-thanks__cta d-lg-none' onClick={onClick}>
+const MessengerButton = ({ onClick, cohort }) => (
+  <a className={`petition-thanks__cta d-lg-none ${addBrandedColorClass('messenger', cohort)}`} onClick={onClick}>
     <MessengerSvg />
     Share on Messenger
   </a>
 )
 
 MessengerButton.propTypes = {
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  cohort: PropTypes.bool
 }
 
 export default withMessenger(MessengerButton)

--- a/src/components/theme-giraffe/twitter-button.js
+++ b/src/components/theme-giraffe/twitter-button.js
@@ -3,16 +3,18 @@ import PropTypes from 'prop-types'
 
 import { withTwitter } from '../../containers/hoc-twitter'
 import TwitterSvg from 'GiraffeUI/svgs/twitter.svg'
+import { addBrandedColorClass } from '../../lib'
 
-const TwitterButton = ({ onClick }) => (
-  <a className='mo-btn petition-thanks__link' onClick={onClick}>
+const TwitterButton = ({ onClick, cohort }) => (
+  <a className={`mo-btn petition-thanks__link ${addBrandedColorClass('twitter', cohort)}`} onClick={onClick}>
     <TwitterSvg />
     Twitter
   </a>
 )
 
 TwitterButton.propTypes = {
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  cohort: PropTypes.bool
 }
 
 export default withTwitter(TwitterButton)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -221,3 +221,5 @@ export const parseSQSApiResponse = response =>
   })
 
 export const byIdAndName = p => ({ [p.petition_id]: p, [p.name]: p })
+
+export const addBrandedColorClass = (shareType, cohort) => (cohort ? `${shareType}-branded` : '')


### PR DESCRIPTION
This PR:
- Adds logic to render branded colors for Facebook, Facebook Messenger and Twitter Buttons.
- Tied to: https://github.com/MoveOnOrg/giraffe/pull/262
- Branched from #624 which adds the messenger button and removes whatsapp components and functionality